### PR TITLE
Attack delay not on prefab

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -368,8 +368,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   LightDmg: 2
   HeavyDmg: 5
-  LightAtkDelay: 0
-  HeavyAtkDelay: 0
+  LightAtkDelay: 1
+  HeavyAtkDelay: 3
   isAttacking: 0
 --- !u!95 &801336184962160247
 Animator:


### PR DESCRIPTION
assigned values on light and heavy attack delays

![Image](https://github.com/user-attachments/assets/97e99d1f-e8d9-4250-927b-18e71f450966)

![Image](https://github.com/user-attachments/assets/e80a703a-e335-4e11-828c-e33b38b51c78)

https://github.com/Smash-Keyboard-Studios/Studio2/issues/97