### PR TITLE
1B Combat Rework

### DIFF
--- a/Assets/Scenes/Levels/Level 1/Level_1B.unity
+++ b/Assets/Scenes/Levels/Level 1/Level_1B.unity
@@ -702,7 +702,7 @@ PrefabInstance:
     - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 89.5
+      value: 87.169
       objectReference: {fileID: 0}
     - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
         type: 3}
@@ -850,6 +850,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &34112579
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.009998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (55)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &34112580 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 34112579}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &34112581 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 34112579}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &34524224
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -991,110 +1071,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
     type: 3}
   m_PrefabInstance: {fileID: 134200002}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &40275353
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -40.956657
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.72
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 23.783367
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &40275354 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-    type: 3}
-  m_PrefabInstance: {fileID: 40275353}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &40958091 stripped
 Transform:
@@ -1466,6 +1442,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &62374833
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.4800005
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (32)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &62374834 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 62374833}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &62374835 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 62374833}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &63715684 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
@@ -2124,110 +2180,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 34524224}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &115443398
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -30.872345
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.7299998
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.049025
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &115443399 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-    type: 3}
-  m_PrefabInstance: {fileID: 115443398}
-  m_PrefabAsset: {fileID: 0}
 --- !u!43 &118106652
 Mesh:
   m_ObjectHideFlags: 0
@@ -2741,6 +2693,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
+      propertyPath: timeBetweenSpawn
+      value: 0.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
       propertyPath: waveData.Array.size
       value: 3
       objectReference: {fileID: 0}
@@ -2812,7 +2769,7 @@ PrefabInstance:
     - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: waveData.Array.data[0].amount
-      value: 20
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
@@ -2827,7 +2784,7 @@ PrefabInstance:
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -8.84
       objectReference: {fileID: 0}
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
@@ -2837,7 +2794,7 @@ PrefabInstance:
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 33.04
       objectReference: {fileID: 0}
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
@@ -3095,6 +3052,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10eae269a1bbe614882ffda5fc877d60, type: 3}
+--- !u!1001 &138689888
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.389996
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (56)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &138689889 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 138689888}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &138689890 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 138689888}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &144301517
 GameObject:
   m_ObjectHideFlags: 0
@@ -3867,6 +3904,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1030122816}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &178978907
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.0999966
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (65)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &178978908 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 178978907}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &178978909 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 178978907}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &186512794 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
@@ -3991,6 +4108,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &189261976
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12000084
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 33.079998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (82)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &189261977 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 189261976}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &189261978 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 189261976}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &189552122 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
@@ -4990,6 +5187,480 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1860028441}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &233723325
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1394060812}
+    m_Modifications:
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -47.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 41.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 805650235406756631, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 46.96021
+      objectReference: {fileID: 0}
+    - target: {fileID: 805650235406756631, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 53.16819
+      objectReference: {fileID: 0}
+    - target: {fileID: 805650235406756631, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 13.480104
+      objectReference: {fileID: 0}
+    - target: {fileID: 805650235406756631, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 9.940423
+      objectReference: {fileID: 0}
+    - target: {fileID: 3201583495541870167, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Name
+      value: ArcadeSpectralWall
+      objectReference: {fileID: 0}
+    - target: {fileID: 3238101737048398794, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 3238101737048398794, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 4855243818425692963, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1115224630}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1115224630}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_VersionIndex
+      value: 3094
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedFaces.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[4].x
+      value: -0.0000038533713
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[5].x
+      value: -0.0000038533713
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[6].x
+      value: -0.0000038533713
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[7].x
+      value: -0.0000038533713
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[8].z
+      value: -0.000000059604645
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[9].z
+      value: -0.000000059604645
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[5].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[5].z
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[7].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[7].z
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[8].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[8].z
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[9].x
+      value: 0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[9].z
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[10].z
+      value: -0.000000059604645
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[11].z
+      value: -0.000000059604645
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[12].x
+      value: 0.0000033843482
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[13].x
+      value: 0.0000033843482
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[14].x
+      value: 0.0000033843482
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Tangents.Array.data[15].x
+      value: 0.0000033843482
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[4].x
+      value: -0.000015413485
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[5].x
+      value: -0.37125176
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[6].x
+      value: -0.000015413485
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[7].x
+      value: -0.37125176
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[8].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[9].x
+      value: 0.0000012785198
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[10].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[10].z
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[11].x
+      value: 0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[11].z
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[12].x
+      value: 0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[12].z
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[14].x
+      value: 0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[14].z
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[18].x
+      value: 0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[18].z
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[19].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[19].z
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[20].x
+      value: 0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[20].z
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[21].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Positions.Array.data[21].z
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[10].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[11].x
+      value: 0.0000012785198
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[12].x
+      value: 0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[14].x
+      value: 0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[18].x
+      value: 0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[18].y
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[19].x
+      value: 4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[19].y
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[20].x
+      value: -0.0000012563924
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[20].y
+      value: -0.37123612
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[21].x
+      value: -4.0000014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Textures0.Array.data[21].y
+      value: -0.37123635
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedFaces.Array.data[0]
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedVertices.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[0].a
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[0].b
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[1].a
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[1].b
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[2].a
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[2].b
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[3].a
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedEdges.Array.data[3].b
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedVertices.Array.data[0]
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedVertices.Array.data[1]
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedVertices.Array.data[2]
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869772078396016276, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_SelectedVertices.Array.data[3]
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 6409057849300663097, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1115224630}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 570c45790054b2b43a9fdba7b8184971, type: 3}
+--- !u!4 &233723326 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 263182170095095762, guid: 570c45790054b2b43a9fdba7b8184971,
+    type: 3}
+  m_PrefabInstance: {fileID: 233723325}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &234856830 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2453926793130249362, guid: 2c832b7d31cae4443969c16b56002386,
@@ -5143,110 +5814,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2453926793130249362, guid: 2c832b7d31cae4443969c16b56002386,
     type: 3}
   m_PrefabInstance: {fileID: 921996475}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &253688703
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_Name
-      value: Ranged AI (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8897304238968218981, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -26.743616
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.7199991
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 28.79858
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 29e4edd3b221e1b4fabf45c30390f4e3, type: 3}
---- !u!4 &253688704 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-    type: 3}
-  m_PrefabInstance: {fileID: 253688703}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &256982273
 PrefabInstance:
@@ -5514,6 +6081,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &265641794
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.970001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.4700003
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (27)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &265641795 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 265641794}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &265641796 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 265641794}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &268170066
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6031,109 +6678,85 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
---- !u!1001 &282813418
+--- !u!1001 &282627957
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
+    m_TransformParent: {fileID: 484792077}
     m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (8)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -45.47014
+      value: -7.970001
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.72
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 23.375774
+      value: 14.4800005
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
+      propertyPath: m_Name
+      value: AI Spawnpoint (33)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &282813419 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &282627958 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
     type: 3}
-  m_PrefabInstance: {fileID: 282813418}
+  m_PrefabInstance: {fileID: 282627957}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &282627959 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 282627957}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &283535041
 GameObject:
@@ -7931,6 +8554,166 @@ Transform:
   - {fileID: 391364038}
   m_Father: {fileID: 98613641}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &370349316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25.190002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (77)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &370349317 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 370349316}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &370349318 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 370349316}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &370911052
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.389996
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (68)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &370911053 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 370911052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &370911054 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 370911052}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &372127988
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7999,6 +8782,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4a4f18026d7c7c440927a8ea9d473661, type: 3}
+--- !u!1001 &376578112
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.9899998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &376578113 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 376578112}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &376578114 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 376578112}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &379569356
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9489,7 +10352,7 @@ PrefabInstance:
     - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 89.5
+      value: 87.169
       objectReference: {fileID: 0}
     - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
         type: 3}
@@ -9629,6 +10492,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 400383415}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &403554077
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.4700003
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (28)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &403554078 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 403554077}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &403554079 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 403554077}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &404071946 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -9709,6 +10652,166 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4a4f18026d7c7c440927a8ea9d473661, type: 3}
+--- !u!1001 &409736608
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.670001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (23)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &409736609 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 409736608}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &409736610 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 409736608}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &410045089
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.9699993
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (53)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &410045090 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 410045089}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &410045091 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 410045089}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &411750278
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9856,6 +10959,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 773900031316004140, guid: 5f22c129a9a6eac4f815716bf47a4956,
     type: 3}
   m_PrefabInstance: {fileID: 419333379}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &422357179
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.0199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (22)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &422357180 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 422357179}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &422357181 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 422357179}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &424906884 stripped
 Transform:
@@ -10381,6 +11564,86 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1001 &439976262
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.009998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (44)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &439976263 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 439976262}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &439976264 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 439976262}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &441279422 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -10641,6 +11904,166 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c4afcfa87699ef64bbfbf611d84cc05e, type: 3}
+--- !u!1001 &450827619
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12000084
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (51)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &450827620 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 450827619}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &450827621 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 450827619}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &451399568
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12000084
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (40)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &451399569 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 451399568}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &451399570 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 451399568}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &451919167 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8677175388151937897, guid: 4a4f18026d7c7c440927a8ea9d473661,
@@ -10806,6 +12229,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
     type: 3}
   m_PrefabInstance: {fileID: 1191775366}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &462268585
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 29.099998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (80)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &462268586 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 462268585}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &462268587 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 462268585}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &463887661
 PrefabInstance:
@@ -11073,6 +12576,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &476500922
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.4800005
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (34)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &476500923 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 476500922}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &476500924 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 476500922}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &477350244 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5660892093653123077, guid: ee73234ddfc943b4d81184a6c985a39b,
@@ -11091,6 +12674,123 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 593847852}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &484792076
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 484792077}
+  m_Layer: 0
+  m_Name: Room1Spawners
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &484792077
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 484792076}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -27.71, y: -2.4, z: 10.53}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 506553846}
+  - {fileID: 376578113}
+  - {fileID: 1850472765}
+  - {fileID: 1622407490}
+  - {fileID: 1844225256}
+  - {fileID: 409736609}
+  - {fileID: 1030119938}
+  - {fileID: 528636426}
+  - {fileID: 403554078}
+  - {fileID: 265641795}
+  - {fileID: 1894405510}
+  - {fileID: 1513862780}
+  - {fileID: 1820288540}
+  - {fileID: 1583621263}
+  - {fileID: 476500923}
+  - {fileID: 1468805057}
+  - {fileID: 2003347514}
+  - {fileID: 1155585037}
+  - {fileID: 370911053}
+  - {fileID: 1885996506}
+  - {fileID: 876674919}
+  - {fileID: 178978908}
+  - {fileID: 856339380}
+  - {fileID: 1027553830}
+  - {fileID: 1196372804}
+  - {fileID: 837885237}
+  - {fileID: 370349317}
+  - {fileID: 1263938437}
+  - {fileID: 462268586}
+  - {fileID: 1190930238}
+  - {fileID: 1294079830}
+  - {fileID: 2039821272}
+  - {fileID: 1618459505}
+  - {fileID: 674528305}
+  - {fileID: 189261977}
+  - {fileID: 931516375}
+  - {fileID: 1434689824}
+  - {fileID: 1622703382}
+  - {fileID: 918640610}
+  - {fileID: 2082724074}
+  - {fileID: 2008569556}
+  - {fileID: 1635183424}
+  - {fileID: 644716725}
+  - {fileID: 953575630}
+  - {fileID: 1003856316}
+  - {fileID: 1506001902}
+  - {fileID: 410045090}
+  - {fileID: 829837011}
+  - {fileID: 450827620}
+  - {fileID: 1546889275}
+  - {fileID: 138689889}
+  - {fileID: 903072289}
+  - {fileID: 34112580}
+  - {fileID: 282627958}
+  - {fileID: 62374834}
+  - {fileID: 1987588753}
+  - {fileID: 1503230823}
+  - {fileID: 1920741395}
+  - {fileID: 1238863292}
+  - {fileID: 1835549898}
+  - {fileID: 865274801}
+  - {fileID: 930188328}
+  - {fileID: 451399569}
+  - {fileID: 1283605752}
+  - {fileID: 1423579039}
+  - {fileID: 912489233}
+  - {fileID: 439976263}
+  - {fileID: 1649361388}
+  - {fileID: 1133783540}
+  - {fileID: 1603170063}
+  - {fileID: 589001383}
+  - {fileID: 1764297313}
+  - {fileID: 2065490776}
+  - {fileID: 422357180}
+  - {fileID: 1368616319}
+  - {fileID: 1307310470}
+  - {fileID: 1120146116}
+  - {fileID: 1718992976}
+  - {fileID: 1416167872}
+  - {fileID: 2122197982}
+  - {fileID: 1284309770}
+  - {fileID: 587343257}
+  - {fileID: 1337761830}
+  - {fileID: 805324838}
+  - {fileID: 1697733172}
+  - {fileID: 2065890837}
+  m_Father: {fileID: 1394060812}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &484910173
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11744,6 +13444,86 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1001 &506553845
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.9899998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.879999
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &506553846 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 506553845}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &506553847 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 506553845}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &507181779 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 722473921180735867, guid: c4afcfa87699ef64bbfbf611d84cc05e,
@@ -12117,6 +13897,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10eae269a1bbe614882ffda5fc877d60, type: 3}
+--- !u!1001 &528636425
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.670001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (25)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &528636426 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 528636425}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &528636427 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 528636425}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &529219149
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13578,6 +15438,171 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 460278501}
   m_PrefabAsset: {fileID: 0}
+--- !u!43 &570173377
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh-91760
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 684
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 358
+    localAABB:
+      m_Center: {x: -9.351657, y: 4.0700006, z: 10.934397}
+      m_Extent: {x: 23.8848, y: 5.9300003, z: 11.054962}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 0
+  m_KeepIndices: 0
+  m_IndexFormat: 0
+  m_IndexBuffer: 0000010002000000030001000000040003000500040000000600050000000700060008000600070009000a00060009000a000500060005000b000c000b0005000a000d000e000f0010000f000e0011000e000d00120011000d0012001300110014001100130015000e001100150016000e001700160015001800170015001900180015001a001b001c001b001d001c001e001f0020001f00210020002200230024002300250024002600270028002700290028002a002b002c002b002d002c002e002f0030002f00310030003200330034003300350034003600370038003700390038003a003b003c003b003d003c003e003f0040003f00410040004200430044004300450044004600470048004700490048004a004b004c004b004d004c004e004f00500051004f004e00520053005400520055005300530055004e00550051004e00550056005100560057005100580057005600560059005a005a005b00560056005b0058005c005d005b005b005d00580058005d005e005d005f005e005d0060005f005f0060006100600062006100610062006300610063006400630065006400630066006500660067006500670068006500650068006900690068006a0068006b006a006c006a006b006c006d006e006d006c006b006b006f006d00700071006b00720071007300720074007100710074006b0074006f006b007500760077007500770078007800770079007a0078007900750078007b007c007600750075007d007c007e007c007d0075007f007d007f00750080007f0080008100810080008200820080008300820083008400820084008500860082008500860085008700850088008700870088008900870089008a008a0089008b008c008a008b008c008b008d008d008b008e008e008b008f008d008e00900090008e009100910092009000900093008d0094009300900094009000950096009400950096009500970097009500980099009700980096009a0094009b009a0096009c009d009e009d009f009e00a000a100a200a100a300a200a400a500a600a500a700a600a800a900aa00a900ab00aa00ac00ad00ae00ad00af00ae00b000b100b200b100b300b200b400b500b600b500b700b600b800b900ba00b900bb00ba00bc00bd00be00bd00bf00be00c000c100c200c100c300c200c400c500c600c500c700c600c800c900ca00c900cb00ca00cc00cd00ce00cd00cf00ce00d000d100d200d100d300d200d400d500d600d500d700d600d800d900da00d900db00da00dc00dd00de00dd00df00de00e000e100e200e100e300e200e400e500e600e500e700e600e800e900ea00e900eb00ea00ec00ed00ee00ed00ef00ee00f000f100f200f100f300f200f400f500f600f500f700f600f800f900fa00f900fb00fa00fc00fd00fe00fd00ff00fe00000101010201010103010201040105010601050107010601080109010a0109010b010a010c010d010e010d010f010e011001110112011101130112011401150116011501170116011801100119011001120119011a011b011c011b011d011c011e011f0120011f01210120012201230124012301250124012601270128012701290128012a012b012c012b012d012c012e012f0130012f01310130013201330134013301350134013601370138013801370139013a013b013c013d013a01390139013a013c013c01380139013e013f014001400141013e013e01410142014001430141013e0144013f013f01440145014601470148014701490148014a014b014c014b014d014c014e014f0150014f01510150015201530154015301550154015601570158015701590158015a015b015c015b015d015c015e015f0160015f0161016001620163016401630165016401
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 358
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 17184
+    _typelessdata: b53f44c0ffff1f41d5a8af402a3a22340000803ffdf2c0b40000803f2b3a22b42d3a22b3000080bfb83f44c0d6a8af40b92171c001002041cf1a054130794b340000803ff65428b50000803f32794bb433794bb3000080bfbc2171c0cf1a054191af2bc0ffff1f41fd6fb24021041b340000803f90552bb50000803f23041bb423041bb3000080bf94af2bc0fe6fb24029d28cc001002041223f0141ac07a4340000803ff3841bb50000803fae07a4b4ad07a4b3000080bf2ad28cc0223f0141d50d58c0ffff1f41cdcaa84039184a340000803f8bb591b40000803f3a184ab43c184ab3000080bfd80d58c0cecaa8401d0c3dc0ffff1f417bf68840ab929a330000803ff56d2d340000803fab929ab3f56dad1c000080bf200c3dc07cf68840b53f24c0ffff1f41d5a88740750d9fb30000803fd09a61340000803f750d9f33d09ae19c000080bfb83f24c0d6a88740abf687bd00002041a9512f406cd24fb40000803ff925a8340000803f6cd24f34f925a89d000080bf00f787bdab512f406b7fc8bfffff1f41d5a88740000000000000803fa9aa2a350000803f0000000000000000000080bf707fc8bfd6a887408a0b29350000204118eaf3b4623552b40000803f4895e4330000803f623552344895e49c000080bf000050aa0000002ac9e7c0c0000020416debf6bd9b58ed330000803f13a916340000803f9b58edb313a9161d000080bfcae7c0c030ebf6bddff0bfc000002041bf543540c6d235340000803fea97a2340000803fc6d235b400000000000080bfe0f0bfc0c1543540ebb68fc0ffff1f4151e48a40bf1ecd320000803fa67423350000803fbf1ecdb200000000000080bfecb68fc052e48a40cae7c0c00000000030ebf6bd9d58edb3000080bf13a916b4000080bf9d58ed3313a9961c000080bfcae7c04030ebf6bd200c3dc0000080b57cf68840ad929ab3000080bff66d2db4000080bfad929a33f66dad1c000080bf200c3d407cf68840e0f0bfc000000000c1543540c8d235b4000080bfeb97a2b4000080bfc8d23534eb97a21d000080bfe0f0bf40c1543540ecb68fc0000080b552e48a40c21ecdb2000080bfa77423b5000080bfc21ecd32a774a31c000080bfecb68f4052e48a40b83f24c0000080b5d6a88740750d9f33000080bfd09a61b4000080bf750d9fb300000000000080bfb83f2440d6a8874000000000000000000000000062355234000080bf4995e4b3000080bf623552b44995e41c000080bf000000000000000000f787bd00000000ab512f406cd24f34000080bff925a8b4000080bf6cd24fb4f925a81d000080bf00f7873dab512f40707fc8bf000080b5d6a8874000000000000080bfa9aa2ab5000080bf0000000000000000000080bf707fc83fd6a88740b83f44c0000080b5d6a8af402d3a22b4000080bffef2c034000080bf2d3a2234fef2c01d000080bfb83f4440d6a8af40d80d58c0000080b5cecaa8403c184ab4000080bf8eb59134000080bf3c184a3400000000000080bfd80d5840cecaa8402ad28cc000008035223f0141b007a4b4000080bff6841b35000080bfb007a43400000000000080bf2ad28c40223f0141bc2171c000008035cf1a054135794bb4000080bff7542835000080bf35794b34f754281e000080bfbc217140cf1a054194af2bc0000080b5fe6fb24022041bb4000080bf91552b35000080bf22041b3491552b1e000080bf94af2b40fe6fb240bc2171c000008035cf1a0541960c6e3f5ad48eb3b458bc3eb458bcbe5ad40e27960c6e3f000080bf82f211414716783594af2bc0000080b5fe6fb240960c6e3f5dfd77b3b358bc3eb358bcbe00000000960c6e3f000080bfff80c540ddf483b5b92171c001002041cf1a0541960c6e3f5dfd77b3b358bc3eb358bcbe00000000960c6e3f000080bf82f211410100204191af2bc0ffff1f41fd6fb240960c6e3f065252b3b258bc3eb258bcbe00000000960c6e3f000080bffe80c540ffff1f4194af2bc0000080b5fe6fb2404ce9613e7dc385b33cb179bf3cb1793f7dc385264ce9613e000080bf3c72b1bfcd6ab2b5b83f44c0000080b5d6a8af404ce9613e7dc385b33cb179bf3cb1793f7dc385264ce9613e000080bf37d0e3bfcd6ab2b591af2bc0ffff1f41fd6fb2404ce9613e7dc385b33cb179bf3cb1793f7dc385264ce9613e000080bf3772b1bfffff1f41b53f44c0ffff1f41d5a8af404ce9613e7dc385b33cb179bf3cb1793f7dc385264ce9613e000080bf32d0e3bfffff1f412ad28cc000008035223f01410745b6bed3d09132973a6f3f973a6fbf000000000745b6be000080bfd14a9e3fbe765635bc2171c000008035cf1a05410545b6be0545b632973a6f3f973a6fbf000000000545b6be000080bf212f0f3fbe76563529d28cc001002041223f01410545b6be0545b632973a6f3f973a6fbf000000000545b6be000080bfcd4a9e3f01002041b92171c001002041cf1a05410345b6be37b9da32973a6f3f973a6fbf000000000345b6be000080bf162f0f3f01002041d80d58c0000080b5cecaa840906f70bfb3335a336fcdafbe6fcdaf3eb333da26906f70bf000080bf669fc3c00f4589b52ad28cc000008035223f0141906f70bf7a464d3370cdafbe70cdaf3e00000000906f70bf000080bfae9011c1e2756d35d50d58c0ffff1f41cdcaa840906f70bf7a464d3370cdafbe70cdaf3e00000000906f70bf000080bf649fc3c0ffff1f4129d28cc001002041223f0141906f70bf4059403370cdafbe70cdaf3e00000000906f70bf000080bfae9011c101002041200c3dc0000080b57cf6884042ab6bbf78d14a331af6c7be1af6c73e0000000042ab6bbf000080bf6e00a3c0eca386b5d80d58c0000080b5cecaa84042ab6bbf78d14a331af6c7be1af6c73e78d1ca2642ab6bbf000080bfb493c5c0eca386b51d0c3dc0ffff1f417bf6884042ab6bbf78d14a331af6c7be1af6c73e78d1ca2642ab6bbf000080bf6d00a3c0ffff1f41d50d58c0ffff1f41cdcaa84042ab6bbf78d14a331af6c7be1af6c73e0000000042ab6bbf000080bfb293c5c0ffff1f41b83f44c0000080b5d6a8af40a6b06d3fd02a51b3ec26be3eec26bebe00000000a6b06d3f000080bfcc89c740af4885b5b83f24c0000080b5d6a88740a6b06d3fd02a51b3ec26be3eec26bebe00000000a6b06d3f000080bffb749c40af4885b5b53f44c0ffff1f41d5a8af40a6b06d3fd02a51b3ec26be3eec26bebe00000000a6b06d3f000080bfcb89c740ffff1f41b53f24c0ffff1f41d5a88740a6b06d3fd02a51b3ec26be3eec26bebe00000000a6b06d3f000080bffa749c40ffff1f41b83f24c0000080b5d6a8874000000000cdcc4c330000803f000080bf0000000000000000000080bfb83f2440c4219bb5707fc8bf000080b5d6a8874000000000cccc4c330000803f000080bf0000000000000000000080bf707fc83fc4219bb5b53f24c0ffff1f41d5a8874000000000cccc4c330000803f000080bf0000000000000000000080bfb53f2440ffff1f416b7fc8bfffff1f41d5a8874000000000cccc4c330000803f000080bf0000000000000000000080bf6b7fc83fffff1f41707fc8bf000080b5d6a88740f404353fc9d010b2f204353ff20435bf00000000f404353f000080bf7e5e834027b97bb500f787bd00000000ab512f40f404353f677127b2f204353ff30435bf6771a7a5f404353f000080bf89f2fd3f2fdb88326b7fc8bfffff1f41d5a88740f404353f677127b2f204353ff30435bf6771a7a5f404353f000080bf7c5e8340ffff1f41abf687bd00002041a9512f40f404353f05123eb2f204353ff30435bf0512bea5f404353f000080bf82f2fd3f0000204100f787bd00000000ab512f40c3ec7f3fa77a85b3197ac63c1b7ac6bcda541425c4ec7f3f000080bfd95e2f4088ca22a4000000000000000000000000c3ec7f3fe42785b3187ac63c1a7ac6bcff940c25c4ec7f3f000080bf0000000000000000abf687bd00002041a9512f40c3ec7f3fe42785b3187ac63c1a7ac6bcff940c25c4ec7f3f000080bfd75e2f40000020418a0b29350000204118eaf3b4c3ec7f3f20d584b3187ac63c1a7ac6bc22d50425c4ec7f3f000080bfbc08fcb4000020410000000000000000000000009dcea33c3b8048b3e6f27fbfe6f27f3f9e6420a49dcea33c000080bf0000000000000000cae7c0c00000000030ebf6bd9dcea33ce7e047b3e6f27fbfe6f27f3f9e64a0a39dcea33c000080bfabf1c0c0c0c571a58a0b29350000204118eaf3b49dcea33ce7e047b3e6f27fbfe6f27f3f9e64a0a39dcea33c000080bf9892263500002041c9e7c0c0000020416debf6bd9dcea33c934147b3e6f27fbfe6f27f3f000000009dcea33c000080bfaaf1c0c000002041e0f0bfc000000000c1543540ee0435bfc2d09033f804353ff80435bfc2d01027ef0435bf000080bfa6390f40cb15e2b4ecb68fc0000080b552e48a40ee0435bfc2d09033f804353ff80435bfc2d01027ef0435bf000080bf1141da3d7385b8b5dff0bfc000002041bf543540ee0435bfc2d09033f804353ff80435bfc2d01027ef0435bf000080bfa6390f4000002041ebb68fc0ffff1f4151e48a40ee0435bfc2d09033f804353ff80435bfc2d01027ef0435bf000080bf1141da3dffff1f41ecb68fc0000080b552e48a40e780203d169e4433aacd7f3fabcd7fbf189e44a5e880203d000080bff40b9540169199b5200c3dc0000080b57cf68840e680203d7a9c4233aacd7f3fabcd7fbf7c9c42a5e780203d000080bfd5a24740169199b5ebb68fc0ffff1f4151e48a40e680203d7a9c4233aacd7f3fabcd7fbf7c9c42a5e780203d000080bff30b9540ffff1f411d0c3dc0ffff1f417bf68840e680203ddd9a4033aacd7f3fabcd7fbf00000000e780203d000080bfd2a24740ffff1f41cae7c0c00000000030ebf6bd97fc7fbff2c74e33f52b273cf52b27bc0000000097fc7fbf000080bf1d703a3ef8c69bb4e0f0bfc000000000c154354097fc7fbf7cd44e33f52b273cf52b27bc0000000097fc7fbf000080bf9e6731c0f8c69bb4c9e7c0c0000020416debf6bd97fc7fbf7cd44e33f52b273cf52b27bc0000000097fc7fbf000080bf3b703a3e00002041dff0bfc000002041bf54354097fc7fbf06e14e33f52b273cf52b27bc0000000097fc7fbf000080bf9c6731c00000204112f02a41703d024135ea9341000000000000803f000000000000803f0000000000000000000080bfc05e76c000f1cc3e12f00e41703d024135eaad41000000000000803f000000000000803f0000000000000000000080bf602fb3c0209e694012f02a41703d024135eaa141000000000000803f000000000000803f0000000000000000000080bfc05e76c0209e094048c04b40703d024135eaad41000000000000803f000000000000803f0000000000000000000080bfb09735c1209e6940c2876841703d024171b69041000000000000803f000000000000803f0000000000000000000080bf000000000000000012f03241703d024135ea9141000000000000803f000000000000803f0000000000000000000080bfc05e56c000e2193e12f06241703d024135ea9541000000000000803f000000000000803f0000000000000000000080bf00f6b2be8078263f12f02a41703d024135ea8d41000000000000803f000000000000803f0000000000000000000080bfc05e76c0000fb3be76dd2841703d02416d6d8241000000000000803f000000000000803f0000000047379933000080bf30a97ec04090e4bf9080d73f703d024135eaa341000000000000803f000000000000803f0000000000000000000080bfb0974dc1209e19409080d73f703d024135ea8f41000000000000803f000000000000803f0000000087556133000080bfb0974dc1003cccbd76dd2841703d02413b616541000000000000803f000000000000803f0000000018e0f734000080bf30a97ec0a02e70c05cd41041703d0241237d4e41000000000000803f000000000000803f0000000002ab7934000080bfcc66afc080dfa5c0dc754040703d024122584d41000000000000803f000000000000803f00000000f87570b2000080bf4b6a38c18029a8c0f8cac93f703d024139176341000000000000803f000000000000803f000000006a8490b4000080bf634e4fc1a85679c0e8a2c03f703d0241b8038d41000000000000803f000000000000803f0000000080ad99b1000080bf657350c140aeecbe9080973f703d024135ea9141000000000000803f000000000000803f0000000000000000000080bfb09755c100e2193e707fa8bf703d024135ea8f41000000000000803f000000000000803f0000000000000000000080bfb0977dc1003cccbdb0aacdbf703d0241f7278c41000000000000803f000000000000803f0000000000000000000080bf8c1e81c140cf11bfb83f04c0703d024135ea9341000000000000803f000000000000803f0000000000000000000080bfd8cb84c100f1cc3e987b1bc0703d02417a048f41000000000000803f000000000000803f0000000000000000000080bf54b387c180fb58bed0b554c0703d02413abb8e41000000000000803f000000000000803f0000000000000000000080bf9bda8ec1809b7dbeb83f74c0703d024135ea9341000000000000803f000000000000803f0000000000000000000080bfd8cb92c100f1cc3edc1f82c0703d024135ea8d41000000000000803f000000000000803f0000000000000000000080bfd8cb94c1000fb3bed8935bc0703d0241374c8b41000000000000803f000000000000803f0000000000000000000080bf5cb68fc140472dbfe8e36dc0703d0241b1258641000000000000803f000000000000803f0000000000000000000080bf5e0092c1000ca9bf4c7fcac0703d02413d059141000000000000803f000000000000803f0000000000000000000080bfb4e3a6c100981d3ddc1fc2c0703d024135ea9541000000000000803f000000000000803f0000000000000000000080bfd8cba4c18078263fdc1fdac0703d024135ea9341000000000000803f000000000000803f0000000000000000000080bfd8cbaac100f1cc3e60aadbc0703d02417d4e9141000000000000803f000000000000803f0000000029462333000080bf792eabc1000c983ddc1fdac0703d024135ea9741000000000000803f000000000000803f0000000000000000000080bfd8cbaac18078663fee0f05c1703d024135eaaf41000000000000803f000000000000803f0000000000000000000080bfd8cbb6c1209e7940dc1fdac0703d024135eaa341000000000000803f000000000000803f0000000000000000000080bfd8cbaac1209e1940ee0f65c1703d024135eaaf41000000000000803f000000000000803f0000000000000000000080bfd8cbe6c1209e7940dc1fdac0703d02416bd46741000000000000803f000000000000803f0000000018a4a434000080bfd8cbaac1dc6166c0ee0f01c1703d02416bd44f41000000000000803f000000000000803f00000000f3198133000080bfd8cbb4c1f030a3c0ee0f7dc1703d02416bd46341000000000000803f000000000000803f000000000e375cb2000080bfd8cbf2c1e06176c0ee0f65c1703d02416bd44b41000000000000803f000000000000803f0000000000000000000080bfd8cbe6c1f030abc0ee0f7dc1703d024135eaa141000000000000803f000000000000803f000000006d8bbdb2000080bfd8cbf2c1209e094060aadbc07c14eebf7d4e914100000000000080bf00000000000080bf00000000294623b3000080bf792eab41000c983dee0f65c17c14eebf35eaaf4100000000000080bf00000000000080bf0000000000000000000080bfd8cbe641209e7940ee0f7dc17c14eebf35eaa14100000000000080bf00000000000080bf000000006d8bbd32000080bfd8cbf241209e0940ee0f01c17c14eebf6bd44f4100000000000080bf00000000000080bf00000000f41981b3000080bfd8cbb441f030a3c0ee0f7dc17c14eebf6bd4634100000000000080bf00000000000080bf000000000e375c32000080bfd8cbf241e06176c0ee0f65c17c14eebf6bd44b4100000000000080bf00000000000080bf0000000000000000000080bfd8cbe641f030abc0dc1fdac07c14eebf6bd4674100000000000080bf00000000000080bf0000000018a4a4b4000080bfd8cbaa41dc6166c0ee0f05c17c14eebf35eaaf4100000000000080bf00000000000080bf0000000000000000000080bfd8cbb641209e7940dc1fdac07c14eebf35ea974100000000000080bf00000000000080bf0000000000000000000080bfd8cbaa418078663fdc1fdac07c14eebf35eaa34100000000000080bf00000000000080bf0000000000000000000080bfd8cbaa41209e1940dc1fdac07c14eebf35ea934100000000000080bf00000000000080bf0000000000000000000080bfd8cbaa4100f1cc3e4c7fcac07c14eebf3d05914100000000000080bf00000000000080bf0000000000000000000080bfb4e3a64100981d3ddc1fc2c07c14eebf35ea954100000000000080bf00000000000080bf0000000000000000000080bfd8cba4418078263fdc1f82c07c14eebf35ea8d4100000000000080bf00000000000080bf0000000000000000000080bfd8cb9441000fb3bee8e36dc07c14eebfb125864100000000000080bf00000000000080bf0000000000000000000080bf5e009241000ca9bfd8935bc07c14eebf374c8b4100000000000080bf00000000000080bf0000000000000000000080bf5cb68f4140472dbfd0b554c07c14eebf3abb8e4100000000000080bf00000000000080bf0000000000000000000080bf9bda8e41809b7dbeb83f74c07c14eebf35ea934100000000000080bf00000000000080bf0000000000000000000080bfd8cb924100f1cc3eb83f04c07c14eebf35ea934100000000000080bf00000000000080bf0000000000000000000080bfd8cb844100f1cc3e987b1bc07c14eebf7a048f4100000000000080bf00000000000080bf0000000000000000000080bf54b3874180fb58beb0aacdbf7c14eebff7278c4100000000000080bf00000000000080bf0000000000000000000080bf8c1e814140cf11bf707fa8bf7c14eebf35ea8f4100000000000080bf00000000000080bf0000000000000000000080bfb0977d41003cccbde8a2c03f7c14eebfb8038d4100000000000080bf00000000000080bf0000000080ad9931000080bf6573504140aeecbe9080973f7c14eebf35ea914100000000000080bf00000000000080bf0000000000000000000080bfb097554100e2193e9080d73f7c14eebf35ea8f4100000000000080bf00000000000080bf00000000875561b3000080bfb0974d41003cccbddc7540407c14eebf22584d4100000000000080bf00000000000080bf00000000f9757032000080bf4b6a38418029a8c0f8cac93f7c14eebf3917634100000000000080bf00000000000080bf000000006a849034000080bf634e4f41a85679c076dd28417c14eebf6d6d824100000000000080bf00000000000080bf00000000473799b3000080bf30a97e404090e4bf5cd410417c14eebf237d4e4100000000000080bf00000000000080bf0000000002ab79b4000080bfcc66af4080dfa5c076dd28417c14eebf3b61654100000000000080bf00000000000080bf0000000018e0f7b4000080bf30a97e40a02e70c09080d73f7c14eebf35eaa34100000000000080bf00000000000080bf0000000000000000000080bfb0974d41209e194048c04b407c14eebf35eaad4100000000000080bf00000000000080bf0000000000000000000080bfb0973541209e694012f02a417c14eebf35ea8d4100000000000080bf00000000000080bf0000000000000000000080bfc05e7640000fb3be12f02a417c14eebf35ea934100000000000080bf00000000000080bf0000000000000000000080bfc05e764000f1cc3e12f032417c14eebf35ea914100000000000080bf00000000000080bf0000000000000000000080bfc05e564000e2193ec28768417c14eebf71b6904100000000000080bf00000000000080bf0000000000000000000080bf000000000000000012f062417c14eebf35ea954100000000000080bf00000000000080bf0000000000000000000080bf00f6b23e8078263f12f00e417c14eebf35eaad4100000000000080bf00000000000080bf0000000000000000000080bf602fb340209e694012f02a417c14eebf35eaa14100000000000080bf00000000000080bf0000000000000000000080bfc05e7640209e094012f00e417c14eebf35eaad41449a263f00000000a45e423fa45e42bf00000000449a263f000080bfcd10d4400000803412f02a417c14eebf35eaa141449a263f00000000a45e423fa45e42bf00000000449a263f000080bf2c4f8a400000803412f00e41703d024135eaad41449a263f00000000a45e423fa45e42bf00000000449a263f000080bfcd10d4400000204112f02a41703d024135eaa141449a263f00000000a45e423fa45e42bf00000000449a263f000080bf2c4f8a400000204112f02a417c14eebf35eaa1410000803f000000000000000000000000000000000000803f000080bf209e09400000803412f02a417c14eebf35ea93410000803f000000000000000000000000000000000000803f000080bf00f1cc3e0000803412f02a41703d024135eaa1410000803f000000000000000000000000000000000000803f000080bf209e09400000204112f02a41703d024135ea93410000803f000000000000000000000000000000000000803f000080bf00f1cc3e0000204148c04b407c14eebf35eaad4100000000000000000000803f000080bf0000000000000000000080bfb09735410000803412f00e417c14eebf35eaad4100000000000000000000803f000080bf0000000000000000000080bf602fb3400000803448c04b40703d024135eaad4100000000000000000000803f000080bf0000000000000000000080bfb09735410000204112f00e41703d024135eaad4100000000000000000000803f000080bf0000000000000000000080bf602fb3400000204112f032417c14eebf35ea9141355828be0000000050847c3f50847cbf00000000355828be000080bf4cdf51400000000012f062417c14eebf35ea9541355828be0000000050847c3f50847cbf00000000355828be000080bf8094733e0000000012f03241703d024135ea9141355828be0000000050847c3f50847cbf00000000355828be000080bf4cdf51400000204112f06241703d024135ea9541355828be0000000050847c3f50847cbf00000000355828be000080bf8094733e0000204112f062417c14eebf35ea95415a7d613f000000007768f23e7768f2be000000005a7d613f000080bfe0fe3c3f00000000c28768417c14eebf71b690415a7d613f000000007768f23e7768f2be000000005a7d613f000080bf000080350000000012f06241703d024135ea95415a7d613f000000007768f23e7768f2be000000005a7d613f000080bfe0fe3c3f00002041c2876841703d024171b690415a7d613f000000007768f23e7768f2be000000005a7d613f000080bf0000803500002041c28768417c14eebf71b690415c4bb93d0000000036f37ebf37f37e3f000000005d4bb93d000080bf000000000000000012f02a417c14eebf35ea8d415c4bb93d0000000036f37ebf37f37e3f000000005d4bb93d000080bf806277c000000000c2876841703d024171b690415c4bb93d0000000036f37ebf37f37e3f000000005d4bb93d000080bf000000000000204112f02a41703d024135ea8d415c4bb93d0000000036f37ebf37f37e3f000000005d4bb93d000080bf806277c00000204112f02a417c14eebf35ea93412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf13d167400000000012f032417c14eebf35ea91412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf240a44400000000012f02a41703d024135ea93412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf13d167400000204112f03241703d024135ea91412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf240a44400000204112f02a417c14eebf35ea8d41ecf67e3f00000000b403b8bdb503b83d00000000edf67e3f000080bfa0b631bf0000000076dd28417c14eebf6d6d8241ecf67e3f00000000b403b8bdb503b83d00000000edf67e3f000080bf78b308c00000000012f02a41703d024135ea8d41ecf67e3f00000000b403b8bdb503b83d00000000edf67e3f000080bfa0b631bf0000204176dd2841703d02416d6d8241ecf67e3f00000000b403b8bdb503b83d00000000edf67e3f000080bf78b308c0000020419080d73f7c14eebf35eaa34120e323bf0000000027aa443f27aa44bf000000001fe323bf000080bfcb5a05410000000048c04b407c14eebf35eaad4120e323bf0000000027aa443f27aa44bf000000001fe323bf000080bf303acc40000000009080d73f703d024135eaa34120e323bf0000000027aa443f27aa44bf000000001fe323bf000080bfcb5a05410000204148c04b40703d024135eaad4120e323bf0000000027aa443f27aa44bf000000001fe323bf000080bf303acc40000020419080d73f7c14eebf35ea8f41000080bf00000000000000000000000000000000000080bf000080bf003ccc3d000080349080d73f7c14eebf35eaa341000080bf00000000000000000000000000000000000080bf000080bf209e19c0000080349080d73f703d024135ea8f41000080bf00000000000000000000000000000000000080bf000080bf003ccc3d000020419080d73f703d024135eaa341000080bf00000000000000000000000000000000000080bf000080bf209e19c00000204176dd28417c14eebf6d6d82410000803f000000000000000000000000000000000000803f000080bf4090e4bf0000000076dd28417c14eebf3b6165410000803f000000000000000000000000000000000000803f000080bfa02e70c00000000076dd2841703d02416d6d82410000803f000000000000000000000000000000000000803f000080bf4090e4bf0000204176dd2841703d02413b6165410000803f000000000000000000000000000000000000803f000080bfa02e70c00000204176dd28417c14eebf3b6165413b8d303f000000001d6139bf1e61393f000000003b8d303f000080bfb406afc0000000005cd410417c14eebf237d4e413b8d303f000000001d6139bf1e61393f000000003b8d303f000080bffc68f1c00000000076dd2841703d02413b6165413b8d303f000000001d6139bf1e61393f000000003b8d303f000080bfb406afc0000020415cd41041703d0241237d4e413b8d303f000000001d6139bf1e61393f000000003b8d303f000080bffc68f1c0000020415cd410417c14eebf237d4e4121e1413c0000000069fb7fbf6afb7f3f0000000022e1413c000080bf245ab1c000000000dc7540407c14eebf22584d4121e1413c0000000069fb7fbf6afb7f3f0000000022e1413c000080bfb36539c1000000005cd41041703d0241237d4e4121e1413c0000000069fb7fbf6afb7f3f0000000022e1413c000080bf245ab1c000002041dc754040703d024122584d4121e1413c0000000069fb7fbf6afb7f3f0000000022e1413c000080bfb36539c100002041f8cac93f7c14eebf39176341c9f17fbf00000000afa1aabcafa1aa3c00000000c8f17fbf000080bf3403684000000000e8a2c03f7c14eebfb8038d41c9f17fbf00000000afa1aabcafa1aa3c00000000c8f17fbf000080bf0062433e00000000f8cac93f703d024139176341c9f17fbf00000000afa1aabcafa1aa3c00000000c8f17fbf000080bf3403684000002041e8a2c03f703d0241b8038d41c9f17fbf00000000afa1aabcafa1aa3c00000000c8f17fbf000080bf0062433e00002041dc7540407c14eebf22584d41e45130bf00000000909939bf9099393f00000000e45130bf000080bf8c9497c000000000f8cac93f7c14eebf39176341e45130bf00000000909939bf9099393f00000000e45130bf000080bf56bad6c000000000dc754040703d024122584d41e45130bf00000000909939bf9099393f00000000e45130bf000080bf8c9497c000002041f8cac93f703d024139176341e45130bf00000000909939bf9099393f00000000e45130bf000080bf56bad6c0000020419080973f7c14eebf35ea91412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf461e4041000080349080d73f7c14eebf35ea8f412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf8a2c3741000080349080973f703d024135ea91412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf461e4041000020419080d73f703d024135ea8f412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf8a2c374100002041707fa8bf7c14eebf35ea8f419bc8cbbd00000000c2ba7e3fc2ba7ebf000000009bc8cbbd000080bf267e7c41000000009080973f7c14eebf35ea91419bc8cbbd00000000c2ba7e3fc2ba7ebf000000009bc8cbbd000080bf134b544100000000707fa8bf703d024135ea8f419bc8cbbd00000000c2ba7e3fc2ba7ebf000000009bc8cbbd000080bf267e7c41000020419080973f703d024135ea91419bc8cbbd00000000c2ba7e3fc2ba7ebf000000009bc8cbbd000080bf134b544100002041e8a2c03f7c14eebfb8038d4164280d3d0000000012d97fbf12d97f3f0000000064280d3d000080bff29450c100000000b0aacdbf7c14eebff7278c4164280d3d0000000012d97fbf12d97f3f0000000064280d3d000080bf1d3381c100000000e8a2c03f703d0241b8038d4164280d3d0000000012d97fbf12d97f3f0000000064280d3d000080bff29450c100002041b0aacdbf703d0241f7278c4164280d3d0000000012d97fbf12d97f3f0000000064280d3d000080bf1d3381c100002041b83f04c07c14eebf35ea9341d5000e3f000000004001553f400155bf00000000d5000e3f000080bff589604100008034707fa8bf7c14eebf35ea8f41d5000e3f000000004001553f400155bf00000000d5000e3f000080bfe01d524100008034b83f04c0703d024135ea9341d5000e3f000000004001553f400155bf00000000d5000e3f000080bff589604100002041707fa8bf703d024135ea8f41d5000e3f000000004001553f400155bf00000000d5000e3f000080bfe01d524100002041b0aacdbf7c14eebff7278c41b725ccbe0000000021c56abf21c56a3f00000000b725ccbe000080bf7d3069c100008034987b1bc07c14eebf7a048f41b725ccbe0000000021c56abf21c56a3f00000000b725ccbe000080bfc28a77c100008034b0aacdbf703d0241f7278c41b725ccbe0000000021c56abf21c56a3f00000000b725ccbe000080bf7d3069c100002041987b1bc0703d02417a048f41b725ccbe0000000021c56abf21c56a3f00000000b725ccbe000080bfc28a77c100002041987b1bc07c14eebf7a048f41e7b4233d00000000a3cb7fbfa3cb7f3f00000000e7b4233d000080bfeaa887c100000000d0b554c07c14eebf3abb8e41e7b4233d00000000a3cb7fbfa3cb7f3f00000000e7b4233d000080bfa8d18ec100000000987b1bc0703d02417a048f41e7b4233d00000000a3cb7fbfa3cb7f3f00000000e7b4233d000080bfeaa887c100002041d0b554c0703d02413abb8e41e7b4233d00000000a3cb7fbfa3cb7f3f00000000e7b4233d000080bfa8d18ec100002041b83f74c07c14eebf35ea934100000000000000000000803f000080bf0000000000000000000080bfd8cb924100008034b83f04c07c14eebf35ea934100000000000000000000803f000080bf0000000000000000000080bfd8cb844100008034b83f74c0703d024135ea934100000000000000000000803f000080bf0000000000000000000080bfd8cb924100002041b83f04c0703d024135ea934100000000000000000000803f000080bf0000000000000000000080bfd8cb844100002041dc1f82c07c14eebf35ea8d41e9dc72bf000000009be8a13e9be8a1be00000000e9dc72bf000080bfb8d4c64000008034b83f74c07c14eebf35ea9341e9dc72bf000000009be8a13e9be8a1be00000000e9dc72bf000080bf6088ad4000008034dc1f82c0703d024135ea8d41e9dc72bf000000009be8a13e9be8a1be00000000e9dc72bf000080bfb8d4c64000002041b83f74c0703d024135ea9341e9dc72bf000000009be8a13e9be8a1be00000000e9dc72bf000080bf6088ad4000002041d0b554c07c14eebf3abb8e413f5b783f00000000875b78be865b783e000000003e5b783f000080bf244792c000000000d8935bc07c14eebf374c8b413f5b783f00000000875b78be865b783e000000003e5b783f000080bf646fa0c000000000d0b554c0703d02413abb8e413f5b783f00000000875b78be865b783e000000003e5b783f000080bf244792c000002041d8935bc0703d0241374c8b413f5b783f00000000875b78be865b783e000000003e5b783f000080bf646fa0c000002041d8935bc07c14eebf374c8b4199ef693f000000002ff1cfbe2ff1cf3e0000000099ef693f000080bfb442fdc000008034e8e36dc07c14eebfb125864199ef693f000000002ff1cfbe2ff1cf3e0000000099ef693f000080bf1ee709c100008034d8935bc0703d0241374c8b4199ef693f000000002ff1cfbe2ff1cf3e0000000099ef693f000080bfb442fdc000002041e8e36dc0703d0241b125864199ef693f000000002ff1cfbe2ff1cf3e0000000099ef693f000080bf1ee709c100002041e8e36dc07c14eebfb12586419b68ecbe00000000971363bf9713633f000000009b68ecbe000080bf3c4179c1000000004c7fcac07c14eebf3d0591419b68ecbe00000000971363bf9713633f000000009b68ecbe000080bf102d94c100000000e8e36dc0703d0241b12586419b68ecbe00000000971363bf9713633f000000009b68ecbe000080bf3c4179c1000020414c7fcac0703d02413d0591419b68ecbe00000000971363bf9713633f000000009b68ecbe000080bf102d94c100002041dc1fc2c07c14eebf35ea95412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf8ab9954100000000dc1f82c07c14eebf35ea8d412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf12d6834100000000dc1fc2c0703d024135ea95412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf8ab9954100002041dc1f82c0703d024135ea8d412ef9e43e000000002ef9643f2ff964bf000000002ff9e43e000080bf12d6834100002041dc1fdac07c14eebf35ea93419be8a1be00000000e9dc723fe9dc72bf000000009be8a1be000080bfd904a14100000000dc1fc2c07c14eebf35ea95419be8a1be00000000e9dc723fe9dc72bf000000009be8a1be000080bfc3b19a4100000000dc1fdac0703d024135ea93419be8a1be00000000e9dc723fe9dc72bf000000009be8a1be000080bfd904a14100002041dc1fc2c0703d024135ea95419be8a1be00000000e9dc723fe9dc72bf000000009be8a1be000080bfc3b19a41000020414c7fcac07c14eebf3d059141803a88bd00000000da6e7fbfdb6e7f3f00000000823a88bd000080bf528aa6c10000000060aadbc07c14eebf7d4e9141803a88bd00000000da6e7fbfdb6e7f3f00000000823a88bd000080bf87d7aac1000000004c7fcac0703d02413d059141803a88bd00000000da6e7fbfdb6e7f3f00000000823a88bd000080bf528aa6c10000204160aadbc0703d02417d4e9141803a88bd00000000da6e7fbfdb6e7f3f00000000823a88bd000080bf87d7aac100002041dc1fdac07c14eebf35ea97410000803f000000000000000000000000000000000000803f000080bf8078663f00008034dc1fdac07c14eebf35ea93410000803f000000000000000000000000000000000000803f000080bf00f1cc3e00008034dc1fdac0703d024135ea97410000803f000000000000000000000000000000000000803f000080bf8078663f00002041dc1fdac0703d024135ea93410000803f000000000000000000000000000000000000803f000080bf00f1cc3e00002041ee0f05c17c14eebf35eaaf41f304353f00000000f304353ff40435bf00000000f404353f000080bfdb51974100000000dc1fdac07c14eebf35eaa341f304353f00000000f304353ff40435bf00000000f404353f000080bf6559864100000000ee0f05c1703d024135eaaf41f304353f00000000f304353ff40435bf00000000f404353f000080bfdb51974100002041dc1fdac0703d024135eaa341f304353f00000000f304353ff40435bf00000000f404353f000080bf6559864100002041dc1fdac07c14eebf35eaa3410000803f000000000000000000000000000000000000803f000080bf209e194000008034dc1fdac0703d024135eaa3410000803f000000000000000000000000000000000000803f000080bf209e194000002041ee0f65c17c14eebf35eaaf4100000000000000000000803f000080bf0000000000000000000080bfd8cbe64100008034ee0f05c17c14eebf35eaaf4100000000000000000000803f000080bf0000000000000000000080bfd8cbb64100008034ee0f65c1703d024135eaaf4100000000000000000000803f000080bf0000000000000000000080bfd8cbe64100002041ee0f05c1703d024135eaaf4100000000000000000000803f000080bf0000000000000000000080bfd8cbb64100002041dc1fdac07c14eebf6bd4674127aa443f0000000020e323bf20e3233f0000000027aa443f000080bfd67683c100008034ee0f01c17c14eebf6bd44f4127aa443f0000000020e323bf20e3233f0000000027aa443f000080bfae1593c100008034dc1fdac0703d02416bd4674127aa443f0000000020e323bf20e3233f0000000027aa443f000080bfd67683c100002041ee0f01c1703d02416bd44f4127aa443f0000000020e323bf20e3233f0000000027aa443f000080bfae1593c10000204160aadbc07c14eebf7d4e91415efa7f3f0000000092be563c93be56bc000000005ffa7f3f000080bf809ab53e00000000dc1fdac07c14eebf6bd467415efa7f3f0000000092be563c93be56bc000000005ffa7f3f000080bf187454c00000000060aadbc0703d02417d4e91415efa7f3f0000000092be563c93be56bc000000005ffa7f3f000080bf809ab53e00002041dc1fdac0703d02416bd467415efa7f3f0000000092be563c93be56bc000000005ffa7f3f000080bf187454c000002041ee0f01c17c14eebf6bd44f4187b5233d00000000a2cb7fbfa2cb7f3f0000000087b5233d000080bf4c48b6c100000000ee0f65c17c14eebf6bd44b4187b5233d00000000a2cb7fbfa2cb7f3f0000000087b5233d000080bf8852e8c100000000ee0f01c1703d02416bd44f4187b5233d00000000a2cb7fbfa2cb7f3f0000000087b5233d000080bf4c48b6c100002041ee0f65c1703d02416bd44b4187b5233d00000000a2cb7fbfa2cb7f3f0000000087b5233d000080bf8852e8c100002041ee0f65c17c14eebf6bd44b41f30435bf00000000f30435bff404353f00000000f40435bf000080bf5cef84c100000000ee0f7dc17c14eebf6bd46341f30435bf00000000f30435bff404353f00000000f40435bf000080bfd4e795c100000000ee0f65c1703d02416bd44b41f30435bf00000000f30435bff404353f00000000f40435bf000080bf5cef84c100002041ee0f7dc1703d02416bd46341f30435bf00000000f30435bff404353f00000000f40435bf000080bfd4e795c100002041ee0f7dc17c14eebf6bd46341000080bf00000000000000000000000000000000000080bf000080bfdc61764000000000ee0f7dc17c14eebf35eaa141000080bf00000000000000000000000000000000000080bf000080bf209e09c000000000ee0f7dc1703d02416bd46341000080bf00000000000000000000000000000000000080bf000080bfdc61764000002041ee0f7dc1703d024135eaa141000080bf00000000000000000000000000000000000080bf000080bf209e09c000002041ee0f7dc17c14eebf35eaa141a45e42bf00000000449a263f459a26bf00000000a45e42bf000080bfe7f2904100000000ee0f65c17c14eebf35eaaf41a45e42bf00000000449a263f459a26bf00000000a45e42bf000080bffd047d4100000000ee0f7dc1703d024135eaa141a45e42bf00000000449a263f459a26bf00000000a45e42bf000080bfe7f2904100002041ee0f65c1703d024135eaaf41a45e42bf00000000449a263f459a26bf00000000a45e42bf000080bffd047d4100002041f787fec147e11e4135eaad41000000000000803f000000000000803f0000000000000000000080bf1000c03f0000c03ff787cec147e11e4135eaad41000000000000803f000000000000803f0000000000000000000080bf0400f0400000c03ffc4303c247e11e4135eaa541000000000000803f000000000000803f00000000c13f45b1000080bf0000003f0000003ff787c2c147e11e4135eaa141000000000000803f000000000000803f000000002dbdd132000080bf0000104100000000f787cec147e11e416bd44b41000000000000803f000000000000803f0000000071271833000080bf0400f0400000f0c0f787fcc147e11e416bd44b41000000000000803f000000000000803f0000000000000000000080bf1000e03f0000f0c0fc4304c247e11e416bd46341000000000000803f000000000000803f00000000bbfb41b2000080bf0000803efeffbfc0f787c0c147e11e416bd46341000000000000803f000000000000803f00000000cb3d0d34000080bf00001441feffbfc0f787c2c1405c8fbd35eaa14100000000000080bf00000000000080bf000000000fc0d3b2000080bf000010c100000000cce904c2405c8fbd35eaa54100000000000080bf00000000000080bf000000004f8b3c31000080bf0060b4bd0000003f22f204c2405c8fbd6bd4634100000000000080bf00000000000080bf00000000c19e3c32000080bf00b4a3bdfeffbfc0f787cec1405c8fbd6bd44b4100000000000080bf00000000000080bf0000000068f318b3000080bf0000f0c00000f0c0f787c0c1405c8fbd6bd4634100000000000080bf00000000000080bf00000000cb3d0db4000080bf000014c1feffbfc09fbffdc1405c8fbd6bd44b4100000000000080bf00000000000080bf0000000000000000000080bf8085ccbf0000f0c0f787cec1405c8fbd35eaad4100000000000080bf00000000000080bf0000000000000000000080bf0000f0c00000c03ff787fec1405c8fbd35eaad4100000000000080bf00000000000080bf0000000000000000000080bf0000c0bf0000c03ff787fec1405c8fbd35eaad4100000000000000000000803f000080bf0000000000000000000080bf1000c0bf00000035f787cec1405c8fbd35eaad4100000000000000000000803f000080bf0000000000000000000080bf0400f0c000000035f787fec147e11e4135eaad4100000000000000000000803f000080bf0000000000000000000080bf1000c0bf00002041f787cec147e11e4135eaad4100000000000000000000803f000080bf0000000000000000000080bf0400f0c000002041cce904c2405c8fbd35eaa5414beb13bf4dfbc23ce5d9503f0ce950bf4efbc2b007f613bf000080bf00c2b8be00460bbcf787fec1405c8fbd35eaad411a7824bf4dfb423c72ef423f7baa43bf134504bbd61325bf000080bfa4d305c000460bbcfc4303c247e11e4135eaa5411a7824bf4dfb423c72ef423f7baa43bf134504bbd61325bf000080bf506f32bfcae81f41f787fec147e11e4135eaad41e80435bf00000000ff04353f9f0435bf405683bb890435bf000080bfa4d305c094d11f41f787cec1405c8fbd35eaad41f304353f00000000f304353ff40435bf00000000f404353f000080bfb0c387c000000035f787c2c1405c8fbd35eaa141f304353f00000000f304353ff40435bf00000000f404353f000080bf88a5cbc000000035f787cec147e11e4135eaad41f304353f00000000f304353ff40435bf00000000f404353f000080bfb0c387c000002041f787c2c147e11e4135eaa141f304353f00000000f304353ff40435bf00000000f404353f000080bf88a5cbc000002041f787cec1405c8fbd6bd44b410000000000000000000080bf0000803f0000000000000000000080bf0400f040000000359fbffdc1405c8fbd6bd44b410000000000000000000080bf0000803f0000000000000000000080bf9085cc3f00000035f787cec147e11e416bd44b410000000000000000000080bf0000803f0000000000000000000080bf0400f04000002041f787fcc147e11e416bd44b410000000000000000000080bf0000803f0000000000000000000080bf1000e03f000020419fbffdc1405c8fbd6bd44b41c1ee33bfb43d2f3c381436bfe316363fb43d2fb063f133bf000080bfa010cd40008238bd22f204c2405c8fbd6bd463412a7834bf66203a3cec8a35bf278e353fa2ed0438577b34bf000080bfd0c68840008238bdf787fcc147e11e416bd44b412a7834bf66203a3cec8a35bf278e353fa2ed0438577b34bf000080bf5087d040d6491f41fc4304c247e11e416bd46341920135bf1903453ca10135bf0405353ffeec8438e30435bf000080bfc8a58c40624a1f41f787c0c1405c8fbd6bd46341449a263f00000000a45e42bfa45e423f00000000449a263f000080bf7093474000000035f787cec1405c8fbd6bd44b41449a263f00000000a45e42bfa45e423f00000000449a263f000080bfc040503f00000035f787c0c147e11e416bd46341449a263f00000000a45e42bfa45e423f00000000449a263f000080bf7093474000002041f787cec147e11e416bd44b41449a263f00000000a45e42bfa45e423f00000000449a263f000080bfc040503f00002041f787c2c1405c8fbd35eaa14130c77f3f00000000cc842a3dcc842abd000000002fc77f3f000080bf40d5bfbe00000035f787c0c1405c8fbd6bd4634130c77f3f00000000cc842a3dcc842abd000000002fc77f3f000080bffc27ccc000000035f787c2c147e11e4135eaa14130c77f3f00000000cc842a3dcc842abd000000002fc77f3f000080bf40d5bfbe00002041f787c0c147e11e416bd4634130c77f3f00000000cc842a3dcc842abd000000002fc77f3f000080bffc27ccc00000204122f204c2405c8fbd6bd4634179f67fbf6b4c8b3c4821a43a5c27a4ba00000000f3ff7fbf000080bf20ffbf4000c0c23acce904c2405c8fbd35eaa54152c77fbf601bee3cff6aa23c8773a2bcc0a7a5391cf37fbf000080bf400700bf00c0c23afc4304c247e11e416bd4634152c77fbf601bee3cff6aa23c8773a2bcc0a7a5391cf37fbf000080bf60fdbf40050c2041fc4303c247e11e4135eaa5412c987fbf2b75283df5491d3dc8501dbd61b5253aa2cf7fbf000080bf202900bfdd1c2041
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -9.351657, y: 4.0700006, z: 10.934397}
+    m_Extent: {x: 23.8848, y: 5.9300003, z: 11.054962}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1.010493
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!4 &570596462 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -13929,6 +15954,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &587343256
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.0199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (14)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &587343257 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 587343256}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &587343258 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 587343256}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &587789302
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14162,6 +16267,86 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1001 &589001382
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.389996
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (42)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &589001383 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 589001382}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &589001384 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 589001382}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &589768945
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14706,110 +16891,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10eae269a1bbe614882ffda5fc877d60, type: 3}
---- !u!1001 &609935796
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -28.606321
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.72
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 24.637543
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &609935797 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-    type: 3}
-  m_PrefabInstance: {fileID: 609935796}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &610316963
 GameObject:
   m_ObjectHideFlags: 0
@@ -15358,14 +17439,29 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
         type: 3}
+      propertyPath: endOfFadeout.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
       propertyPath: endOfFadein.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: endOfFadeout.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
         type: 3}
       propertyPath: endOfFadein.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1686490282}
+    - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: endOfFadeout.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1686490284}
     - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
         type: 3}
       propertyPath: endOfFadein.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
@@ -15378,12 +17474,32 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
         type: 3}
+      propertyPath: endOfFadeout.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: endOfFadeout.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
       propertyPath: endOfFadein.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: SpawnWave, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
         type: 3}
+      propertyPath: endOfFadeout.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
       propertyPath: endOfFadein.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3228243540281796985, guid: 570c45790054b2b43a9fdba7b8184971,
+        type: 3}
+      propertyPath: endOfFadeout.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 3238101737048398794, guid: 570c45790054b2b43a9fdba7b8184971,
@@ -53215,6 +55331,86 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1001 &644716724
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (45)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &644716725 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 644716724}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &644716726 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 644716724}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &646585399 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -54023,6 +56219,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10eae269a1bbe614882ffda5fc877d60, type: 3}
+--- !u!1001 &674528304
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 33.079998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (83)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &674528305 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 674528304}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &674528306 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 674528304}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &675965438 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -57519,6 +59795,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &805324837
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.879999
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &805324838 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 805324837}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &805324839 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 805324837}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &805382302
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -57922,6 +60278,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 910854807}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &829837010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.0999966
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (52)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &829837011 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 829837010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &829837012 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 829837010}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &831030877
 GameObject:
   m_ObjectHideFlags: 0
@@ -57977,6 +60413,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8677175388151937897, guid: 4a4f18026d7c7c440927a8ea9d473661,
     type: 3}
   m_PrefabInstance: {fileID: 372127988}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &837885236
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (61)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &837885237 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 837885236}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &837885238 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 837885236}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &844914629
 PrefabInstance:
@@ -58207,6 +60723,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &856339379
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.9699993
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (64)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &856339380 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 856339379}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &856339381 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 856339379}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &859329397
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -58355,6 +60951,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &865274800
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (36)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &865274801 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 865274800}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &865274802 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 865274800}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &867938106
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -58807,6 +61483,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &876674918
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12000084
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (66)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &876674919 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 876674918}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &876674920 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 876674918}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &880432727
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -59396,6 +62152,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2035033596}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &903072288
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.259998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (54)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &903072289 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 903072288}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &903072290 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 903072288}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &904210456 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -59606,6 +62442,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10eae269a1bbe614882ffda5fc877d60, type: 3}
+--- !u!1001 &912489232
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.259998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (43)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &912489233 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 912489232}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &912489234 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 912489232}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &915781569
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -59742,6 +62658,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &918640609
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.060005
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (60)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &918640610 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 918640609}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &918640611 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 918640609}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &919829731 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
@@ -60061,6 +63057,86 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1001 &930188327
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (37)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &930188328 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 930188327}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &930188329 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 930188327}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &931076405
 GameObject:
   m_ObjectHideFlags: 0
@@ -60095,6 +63171,86 @@ Transform:
   - {fileID: 1138465440}
   m_Father: {fileID: 1065915117}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &931516374
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (76)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &931516375 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 931516374}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &931516376 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 931516374}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &932206119
 GameObject:
   m_ObjectHideFlags: 0
@@ -60671,6 +63827,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1245448884}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &953575629
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (50)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &953575630 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 953575629}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &953575631 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 953575629}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &957491084
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -60849,7 +64085,7 @@ PrefabInstance:
     - target: {fileID: 6083788038602741258, guid: c518e1c9bb5d615448a69112f6f7b5ea,
         type: 3}
       propertyPath: m_Name
-      value: Gary
+      value: Gary (Lobotomized)
       objectReference: {fileID: 0}
     - target: {fileID: 7128693859107202854, guid: c518e1c9bb5d615448a69112f6f7b5ea,
         type: 3}
@@ -61450,6 +64686,86 @@ Transform:
   - {fileID: 541599084}
   m_Father: {fileID: 431076398}
   m_LocalEulerAnglesHint: {x: 0, y: -90.318, z: 0}
+--- !u!1001 &1003856315
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (49)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1003856316 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1003856315}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1003856317 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1003856315}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1005788844 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -62712,6 +66028,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3d56d25e45bd22d479558b321ce093fb, type: 3}
+--- !u!1001 &1027553829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (63)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1027553830 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1027553829}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1027553831 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1027553829}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1028855767 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
@@ -62723,6 +66119,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
     type: 3}
   m_PrefabInstance: {fileID: 587789302}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1030119937
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.970001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.670001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (24)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1030119938 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1030119937}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1030119939 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1030119937}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1030122816
 PrefabInstance:
@@ -64979,6 +68455,171 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1203222033}
   m_PrefabAsset: {fileID: 0}
+--- !u!43 &1115224630
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: pb_Mesh-97008
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 36
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 24
+    localAABB:
+      m_Center: {x: 2.0000007, y: 1.5, z: -0.18561818}
+      m_Extent: {x: 2.0000007, y: 1.5, z: 0.18561818}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 000001000200010003000200040005000600050007000600080009000a0009000b000a000c000d000e000d000f000e00100011001200110013001200140015001600150017001600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 24
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 40
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 1152
+    _typelessdata: 00000000000000000000000000000000000000000000803f000080bf0000000000000000000080bf000000000000000000008040000000000000000000000000000000000000803f000080bf0000000000000000000080bf000080c00000000000000000000040400000000000000000000000000000803f000080bf0000000000000000000080bf000000000000404000008040000040400000000000000000000000000000803f000080bf0000000000000000000080bf000080c0000040400000804000000000000000000000803f00000000354c8136354c81b6000000000000803f000080bf354c81b7000000000300804000000000b112bebe0000803f00000000354c8136354c81b6000000000000803f000080bfb614bebe000000000000804000004040000000000000803f00000000354c8136354c81b6000000000000803f000080bf354c81b7000040400300804000004040b112bebe0000803f00000000354c8136354c81b6000000000000803f000080bfb614bebe000040400300804000000000b112bebe000080b300000000000080bf0000803f00000000000080b3000080bf030080400000000050a1a83500000000a912bebe000080b300000000000080bf0000803f00000000000080b3000080bf9b99ab35000000000300804000004040b112bebe000080b300000000000080bf0000803f00000000000080b3000080bf030080400000404050a1a83500004040a912bebe000080b300000000000080bf0000803f00000000000080b3000080bf9b99ab350000404050a1a83500000000a912bebe000080bf00000000a91e63b6a91e633600000000000080bf000080bfa912be3e00000000000000000000000000000000000080bf00000000a91e63b6a91e633600000000000080bf000080bf000000000000000050a1a83500004040a912bebe000080bf00000000a91e63b6a91e633600000000000080bf000080bfa912be3e00004040000000000000404000000000000080bf00000000a91e63b6a91e633600000000000080bf000080bf0000000000004040000000000000404000000000000000000000803f000000000000803f0000000000000000000080bf0000000000000000000080400000404000000000000000000000803f000000000000803f0000000000000000000080bf000080400000000050a1a83500004040a912bebe000000000000803f000000000000803f0000000000000000000080bf50a1a835a912bebe0300804000004040b112bebe000000000000803f000000000000803f0000000000000000000080bf03008040b112bebe50a1a83500000000a912bebe00000000000080bf00000000000080bf0000000000000000000080bf50a1a8b5a912bebe0300804000000000b112bebe00000000000080bf00000000000080bf0000000000000000000080bf030080c0b112bebe00000000000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000000000000000000008040000000000000000000000000000080bf00000000000080bf0000000000000000000080bf000080c000000000
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 2.0000007, y: 1.5, z: -0.18561818}
+    m_Extent: {x: 2.0000007, y: 1.5, z: 0.18561818}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1118463453
 GameObject:
   m_ObjectHideFlags: 0
@@ -65029,6 +68670,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &1120146115
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (19)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1120146116 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1120146115}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1120146117 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1120146115}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1122696139
 GameObject:
   m_ObjectHideFlags: 0
@@ -65044,7 +68765,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1122696140
 Transform:
   m_ObjectHideFlags: 0
@@ -65166,6 +68887,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 626046245930698204, guid: 2066d94a6d120bf4dbed360db8cc18a6,
     type: 3}
   m_PrefabInstance: {fileID: 1131932461}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1133783539
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.169999
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (73)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1133783540 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1133783539}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1133783541 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1133783539}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1138465439
 GameObject:
@@ -65329,6 +69130,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &1155585036
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.259998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (69)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1155585037 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1155585036}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1155585038 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1155585036}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1156111580 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -66121,6 +70002,86 @@ Transform:
   - {fileID: 1811955415}
   m_Father: {fileID: 981316289}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1190930237
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 29.099998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (79)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1190930238 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1190930237}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1190930239 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1190930237}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1191723213 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 722473921180735867, guid: c4afcfa87699ef64bbfbf611d84cc05e,
@@ -66274,6 +70235,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
     type: 3}
   m_PrefabInstance: {fileID: 1336394298}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1196372803
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (62)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1196372804 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1196372803}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1196372805 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1196372803}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1198502805 stripped
 Transform:
@@ -66532,110 +70573,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
     type: 3}
   m_PrefabInstance: {fileID: 950368809}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1213251624
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_Name
-      value: Ranged AI
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8897304238968218981, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -44.18215
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.8999999
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 29.0093
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 29e4edd3b221e1b4fabf45c30390f4e3, type: 3}
---- !u!4 &1213251625 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-    type: 3}
-  m_PrefabInstance: {fileID: 1213251624}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1213375075 stripped
 Transform:
@@ -67080,6 +71017,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
     type: 3}
   m_PrefabInstance: {fileID: 1236947313}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1238863291
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (15)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1238863292 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1238863291}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1238863293 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1238863291}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1241187932
 PrefabInstance:
@@ -68422,6 +72439,86 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fadeOutSpeed: 3
+--- !u!1001 &1263938436
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12000084
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 29.099998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (81)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1263938437 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1263938436}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1263938438 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1263938436}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1268809245 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 722473921180735867, guid: c4afcfa87699ef64bbfbf611d84cc05e,
@@ -68617,6 +72714,246 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4a4f18026d7c7c440927a8ea9d473661, type: 3}
+--- !u!1001 &1283605751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.0999966
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (39)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1283605752 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1283605751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1283605753 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1283605751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1284309769
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (13)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1284309770 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1284309769}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1284309771 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1284309769}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1294079829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 29.060001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (78)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1294079830 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1294079829}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1294079831 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1294079829}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1294656348 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -69037,6 +73374,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c832b7d31cae4443969c16b56002386, type: 3}
+--- !u!1001 &1307310469
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.1899996
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1307310470 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1307310469}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1307310471 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1307310469}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1307556422 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -69656,6 +74073,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3d56d25e45bd22d479558b321ce093fb, type: 3}
+--- !u!1001 &1337761829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1337761830 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1337761829}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1337761831 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1337761829}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1339238395
 GameObject:
   m_ObjectHideFlags: 0
@@ -69824,6 +74321,80 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &1350859136
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1873533147}
+    m_Modifications:
+    - target: {fileID: 4937923229752190964, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_Name
+      value: Health Box
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cbede832ace46ff4ab76565732f49820, type: 3}
+--- !u!4 &1350859137 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8850754640990962201, guid: cbede832ace46ff4ab76565732f49820,
+    type: 3}
+  m_PrefabInstance: {fileID: 1350859136}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1353732644 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4781544832472215708, guid: 10013ce3e5332904e84951668a0e0b86,
@@ -70275,110 +74846,6 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!1001 &1367304078
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -23.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &1367304079 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-    type: 3}
-  m_PrefabInstance: {fileID: 1367304078}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1367952394
 GameObject:
   m_ObjectHideFlags: 0
@@ -70502,6 +74969,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
     type: 3}
   m_PrefabInstance: {fileID: 1160343836}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1368616318
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (21)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1368616319 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1368616318}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1368616320 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1368616318}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1369438887
 PrefabInstance:
@@ -70842,18 +75389,10 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1947654259}
-  - {fileID: 115443399}
-  - {fileID: 1623307751}
-  - {fileID: 40275354}
-  - {fileID: 609935797}
-  - {fileID: 1867844488}
-  - {fileID: 1865177914}
-  - {fileID: 282813419}
-  - {fileID: 1367304079}
-  - {fileID: 1213251625}
-  - {fileID: 253688704}
-  - {fileID: 1678266965}
+  - {fileID: 1631055492}
+  - {fileID: 484792077}
+  - {fileID: 233723326}
+  - {fileID: 1475552241}
   m_Father: {fileID: 886490705}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1394199297 stripped
@@ -71110,6 +75649,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1229606742}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1416167871
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.0199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (18)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1416167872 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1416167871}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1416167873 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1416167871}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1417401902
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -71320,6 +75939,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3d56d25e45bd22d479558b321ce093fb, type: 3}
+--- !u!1001 &1423579038
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.9699993
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (38)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1423579039 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1423579038}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1423579040 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1423579038}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1423720040
 GameObject:
   m_ObjectHideFlags: 0
@@ -71618,6 +76317,86 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1001 &1434689823
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (75)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1434689824 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1434689823}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1434689825 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1434689823}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1438272461
 GameObject:
   m_ObjectHideFlags: 0
@@ -72388,6 +77167,180 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 188543750}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1468805056
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (47)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1468805057 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1468805056}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1468805058 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1468805056}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1475552240
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1394060812}
+    m_Modifications:
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9749736
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.2223207
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -25.691
+      objectReference: {fileID: 0}
+    - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4753933575020666142, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1.4846611
+      objectReference: {fileID: 0}
+    - target: {fileID: 4753933575020666142, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 5.9212685
+      objectReference: {fileID: 0}
+    - target: {fileID: 4753933575020666142, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.63640785
+      objectReference: {fileID: 0}
+    - target: {fileID: 4753933575020666142, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -2.0393658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5037576141636716727, guid: 9e25d2db60cabff4bac177ff0757bf31,
+        type: 3}
+      propertyPath: m_Name
+      value: WaveCombat1Trigger
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9e25d2db60cabff4bac177ff0757bf31, type: 3}
+--- !u!4 &1475552241 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
+    type: 3}
+  m_PrefabInstance: {fileID: 1475552240}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1477509057
 GameObject:
   m_ObjectHideFlags: 0
@@ -72911,6 +77864,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2132633555}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1503230822
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (10)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1503230823 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1503230822}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1503230824 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1503230822}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1503709829
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -73035,6 +78068,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &1506001901
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (48)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1506001902 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1506001901}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1506001903 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1506001901}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1506434963 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4781544832472215708, guid: 10013ce3e5332904e84951668a0e0b86,
@@ -73233,6 +78346,86 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1001 &1513862779
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (31)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1513862780 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1513862779}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1513862781 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1513862779}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1514981701 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -74322,6 +79515,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &1546889274
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.169999
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (57)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1546889275 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1546889274}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1546889276 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1546889274}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1550498423 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
@@ -74716,6 +79989,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1965440590}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1583621262
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (29)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1583621263 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1583621262}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1583621264 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1583621262}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1585260329 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4781544832472215708, guid: 10013ce3e5332904e84951668a0e0b86,
@@ -74988,6 +80341,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1601532385}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1603170062
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.009998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (72)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1603170063 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1603170062}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1603170064 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1603170062}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1607723405
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -75124,6 +80557,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c832b7d31cae4443969c16b56002386, type: 3}
+--- !u!1001 &1618459504
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 33.079998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (84)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1618459505 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1618459504}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1618459506 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1618459504}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1619354101
 GameObject:
   m_ObjectHideFlags: 0
@@ -75171,109 +80684,165 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 566028579}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1623307750
+--- !u!1001 &1622407489
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
+    m_TransformParent: {fileID: 484792077}
     m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -34.48002
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.7199981
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.6799965
+      value: -8.879999
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
+      propertyPath: m_Name
+      value: AI Spawnpoint (3)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &1623307751 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1622407490 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
     type: 3}
-  m_PrefabInstance: {fileID: 1623307750}
+  m_PrefabInstance: {fileID: 1622407489}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1622407491 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1622407489}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1622703381
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12000084
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (74)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1622703382 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1622703381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1622703383 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1622703381}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1624931020
 PrefabInstance:
@@ -75644,6 +81213,535 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1720743596}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1631055491
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1394060812}
+    m_Modifications:
+    - target: {fileID: 609190675832279260, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_Name
+      value: Wave Spawner (Mall Room 1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 609190675832279260, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.size
+      value: 86
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[0]
+      value: 
+      objectReference: {fileID: 506553847}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[1]
+      value: 
+      objectReference: {fileID: 376578114}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[2]
+      value: 
+      objectReference: {fileID: 1850472766}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[3]
+      value: 
+      objectReference: {fileID: 1622407491}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[4]
+      value: 
+      objectReference: {fileID: 1844225257}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[5]
+      value: 
+      objectReference: {fileID: 409736610}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[6]
+      value: 
+      objectReference: {fileID: 1030119939}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[7]
+      value: 
+      objectReference: {fileID: 528636427}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[8]
+      value: 
+      objectReference: {fileID: 403554079}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[9]
+      value: 
+      objectReference: {fileID: 265641796}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: waveData.Array.data[0].id
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[10]
+      value: 
+      objectReference: {fileID: 1894405511}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[11]
+      value: 
+      objectReference: {fileID: 1513862781}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[12]
+      value: 
+      objectReference: {fileID: 1820288541}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[13]
+      value: 
+      objectReference: {fileID: 1583621264}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[14]
+      value: 
+      objectReference: {fileID: 476500924}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[15]
+      value: 
+      objectReference: {fileID: 1468805058}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[16]
+      value: 
+      objectReference: {fileID: 2003347515}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[17]
+      value: 
+      objectReference: {fileID: 1155585038}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[18]
+      value: 
+      objectReference: {fileID: 370911054}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[19]
+      value: 
+      objectReference: {fileID: 1885996507}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[20]
+      value: 
+      objectReference: {fileID: 876674920}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[21]
+      value: 
+      objectReference: {fileID: 178978909}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[22]
+      value: 
+      objectReference: {fileID: 856339381}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[23]
+      value: 
+      objectReference: {fileID: 1027553831}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[24]
+      value: 
+      objectReference: {fileID: 1196372805}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[25]
+      value: 
+      objectReference: {fileID: 837885238}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[26]
+      value: 
+      objectReference: {fileID: 370349318}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[27]
+      value: 
+      objectReference: {fileID: 1263938438}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[28]
+      value: 
+      objectReference: {fileID: 462268587}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[29]
+      value: 
+      objectReference: {fileID: 1190930239}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[30]
+      value: 
+      objectReference: {fileID: 1294079831}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[31]
+      value: 
+      objectReference: {fileID: 2039821273}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[32]
+      value: 
+      objectReference: {fileID: 1618459506}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[33]
+      value: 
+      objectReference: {fileID: 674528306}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[34]
+      value: 
+      objectReference: {fileID: 189261978}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[35]
+      value: 
+      objectReference: {fileID: 931516376}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[36]
+      value: 
+      objectReference: {fileID: 1434689825}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[37]
+      value: 
+      objectReference: {fileID: 1622703383}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[38]
+      value: 
+      objectReference: {fileID: 918640611}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[39]
+      value: 
+      objectReference: {fileID: 2082724075}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[40]
+      value: 
+      objectReference: {fileID: 2008569557}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[41]
+      value: 
+      objectReference: {fileID: 1635183425}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[42]
+      value: 
+      objectReference: {fileID: 644716726}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[43]
+      value: 
+      objectReference: {fileID: 953575631}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[44]
+      value: 
+      objectReference: {fileID: 1003856317}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[45]
+      value: 
+      objectReference: {fileID: 1506001903}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[46]
+      value: 
+      objectReference: {fileID: 410045091}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[47]
+      value: 
+      objectReference: {fileID: 829837012}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[48]
+      value: 
+      objectReference: {fileID: 450827621}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[49]
+      value: 
+      objectReference: {fileID: 1546889276}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[50]
+      value: 
+      objectReference: {fileID: 138689890}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[51]
+      value: 
+      objectReference: {fileID: 903072290}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[52]
+      value: 
+      objectReference: {fileID: 34112581}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[53]
+      value: 
+      objectReference: {fileID: 282627959}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[54]
+      value: 
+      objectReference: {fileID: 62374835}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[55]
+      value: 
+      objectReference: {fileID: 1987588754}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[56]
+      value: 
+      objectReference: {fileID: 1503230824}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[57]
+      value: 
+      objectReference: {fileID: 1920741396}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[58]
+      value: 
+      objectReference: {fileID: 1238863293}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[59]
+      value: 
+      objectReference: {fileID: 1835549899}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[60]
+      value: 
+      objectReference: {fileID: 865274802}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[61]
+      value: 
+      objectReference: {fileID: 930188329}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[62]
+      value: 
+      objectReference: {fileID: 451399570}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[63]
+      value: 
+      objectReference: {fileID: 1283605753}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[64]
+      value: 
+      objectReference: {fileID: 1423579040}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[65]
+      value: 
+      objectReference: {fileID: 912489234}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[66]
+      value: 
+      objectReference: {fileID: 439976264}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[67]
+      value: 
+      objectReference: {fileID: 1649361389}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[68]
+      value: 
+      objectReference: {fileID: 1133783541}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[69]
+      value: 
+      objectReference: {fileID: 1603170064}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[70]
+      value: 
+      objectReference: {fileID: 589001384}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[71]
+      value: 
+      objectReference: {fileID: 1764297314}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[72]
+      value: 
+      objectReference: {fileID: 2065490777}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[73]
+      value: 
+      objectReference: {fileID: 422357181}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[74]
+      value: 
+      objectReference: {fileID: 1368616320}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[75]
+      value: 
+      objectReference: {fileID: 1307310471}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[76]
+      value: 
+      objectReference: {fileID: 1120146117}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[77]
+      value: 
+      objectReference: {fileID: 1718992977}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[78]
+      value: 
+      objectReference: {fileID: 1416167873}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[79]
+      value: 
+      objectReference: {fileID: 2122197983}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[80]
+      value: 
+      objectReference: {fileID: 1284309771}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[81]
+      value: 
+      objectReference: {fileID: 587343258}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[82]
+      value: 
+      objectReference: {fileID: 1337761831}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[83]
+      value: 
+      objectReference: {fileID: 805324839}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[84]
+      value: 
+      objectReference: {fileID: 1697733173}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: spawnPoints.Array.data[85]
+      value: 
+      objectReference: {fileID: 2065890838}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: waveData.Array.data[0].amount
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: waveData.Array.data[1].amount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -25.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.099999905
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6f42f3ec645f89347b9c5459b6b8cbec, type: 3}
+--- !u!4 &1631055492 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+    type: 3}
+  m_PrefabInstance: {fileID: 1631055491}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1632197796
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -75717,6 +81815,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 216516126955895849, guid: 275d6fdecfed5954895fed50f3a87440,
     type: 3}
   m_PrefabInstance: {fileID: 991650170}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1635183423
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.970001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (46)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1635183424 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1635183423}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1635183425 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1635183423}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1635490807
 GameObject:
@@ -75957,6 +82135,86 @@ Transform:
   - {fileID: 73357802}
   m_Father: {fileID: 981316289}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1649361387
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.9699993
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (71)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1649361388 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1649361387}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1649361389 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1649361387}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1649936279 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -76380,110 +82638,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c832b7d31cae4443969c16b56002386, type: 3}
---- !u!1001 &1678266964
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_Name
-      value: Ranged AI (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8897304238968218981, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -35.23163
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 14.636507
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 29e4edd3b221e1b4fabf45c30390f4e3, type: 3}
---- !u!4 &1678266965 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 29e4edd3b221e1b4fabf45c30390f4e3,
-    type: 3}
-  m_PrefabInstance: {fileID: 1678266964}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1682009161
 GameObject:
   m_ObjectHideFlags: 0
@@ -76629,7 +82783,7 @@ PrefabInstance:
     - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: timeBetweenSpawn
-      value: 6
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
@@ -76699,7 +82853,7 @@ PrefabInstance:
     - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: waveData.Array.data[0].amount
-      value: 70
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 4649076042481880763, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
@@ -76714,17 +82868,17 @@ PrefabInstance:
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 48
+      value: 12.3
       objectReference: {fileID: 0}
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -4
+      value: -1.17
       objectReference: {fileID: 0}
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -88
+      value: 12.91
       objectReference: {fileID: 0}
     - target: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
         type: 3}
@@ -76772,7 +82926,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 1686490281}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1686490284}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 044b6476a8694734aa82f96ea173357d, type: 3}
@@ -76781,6 +82935,12 @@ MonoBehaviour:
 --- !u!4 &1686490283 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6170390655507320101, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
+    type: 3}
+  m_PrefabInstance: {fileID: 1686490281}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1686490284 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 609190675832279260, guid: 6f42f3ec645f89347b9c5459b6b8cbec,
     type: 3}
   m_PrefabInstance: {fileID: 1686490281}
   m_PrefabAsset: {fileID: 0}
@@ -76931,6 +83091,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
     type: 3}
   m_PrefabInstance: {fileID: 14591253}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1697733171
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1697733172 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1697733171}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1697733173 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1697733171}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1700442156
 PrefabInstance:
@@ -77183,6 +83423,86 @@ Transform:
   - {fileID: 1171465596}
   m_Father: {fileID: 981316289}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1718992975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (17)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1718992976 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1718992975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1718992977 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1718992975}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1720743596
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -77985,6 +84305,86 @@ Transform:
   - {fileID: 1482438108}
   m_Father: {fileID: 1460077073}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1764297312
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.169999
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (41)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1764297313 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1764297312}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1764297314 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1764297312}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1764664396
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -78844,6 +85244,86 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1187601493}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1820288539
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.970001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (30)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1820288540 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1820288539}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1820288541 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1820288539}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1822592118
 GameObject:
   m_ObjectHideFlags: 0
@@ -79073,6 +85553,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1192417144}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1835549897
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.5199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (35)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1835549898 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1835549897}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1835549899 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1835549897}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1836945548
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -79283,6 +85843,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &1844225255
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1844225256 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1844225255}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1844225257 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1844225255}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1845424185 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
@@ -79369,6 +86009,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &1850472764
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.9899998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1850472765 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1850472764}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1850472766 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1850472764}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1851471928 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
@@ -79833,105 +86553,6 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
---- !u!1001 &1865177913
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (7)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -34.690002
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.72
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 8.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &1865177914 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-    type: 3}
-  m_PrefabInstance: {fileID: 1865177913}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1867811380
 GameObject:
   m_ObjectHideFlags: 0
@@ -79980,110 +86601,6 @@ Transform:
   - {fileID: 1059030003}
   m_Father: {fileID: 309240495}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1867844487
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -34.085045
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 24.234592
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &1867844488 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-    type: 3}
-  m_PrefabInstance: {fileID: 1867844487}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1873267060
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -80186,6 +86703,7 @@ Transform:
   - {fileID: 396709107}
   - {fileID: 23735007}
   - {fileID: 1881817052}
+  - {fileID: 1350859137}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1873596734
@@ -80272,6 +86790,2501 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1873596734}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1876845929
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1876845935}
+  - component: {fileID: 1876845934}
+  - component: {fileID: 1876845933}
+  - component: {fileID: 1876845932}
+  - component: {fileID: 1876845931}
+  - component: {fileID: 1876845930}
+  m_Layer: 0
+  m_Name: Temp Collision Fixes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &1876845930
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876845929}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 570173377}
+--- !u!33 &1876845931
+MeshFilter:
+  m_ObjectHideFlags: 10
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876845929}
+  m_Mesh: {fileID: 570173377}
+--- !u!23 &1876845932
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876845929}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 25a9fb42d361f46ad89221f6d301e96e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 2
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &1876845933
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876845929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb977b126bc1b4f15813dcf9da9bb600, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Points:
+  - {x: 0, y: 0, z: 0}
+  - {x: -0.066389084, y: 0, z: 2.7393596}
+  - {x: -1.5663891, y: -0.0000009536743, z: 4.23936}
+  - {x: -2.566389, y: -0.0000009536743, z: 4.23936}
+  - {x: -3.066389, y: -0.0000009536743, z: 5.48936}
+  - {x: -2.6825914, y: -0.0000009536743, z: 5.576171}
+  - {x: -3.767684, y: 0.0000009536743, z: 8.319045}
+  - {x: -4.400655, y: 0.0000009536743, z: 8.077913}
+  - {x: -3.375845, y: -0.0000009536743, z: 5.2747564}
+  - {x: -2.953865, y: -0.0000009536743, z: 4.2800884}
+  - {x: -4.4910793, y: -0.0000009536743, z: 4.340371}
+  - {x: -5.9981537, y: 0, z: 2.833298}
+  - {x: -6.0282946, y: 0, z: -0.12056577}
+  m_Extrude: 10
+  m_EditMode: 0
+  m_FlipNormals: 0
+  isOnGrid: 1
+--- !u!114 &1876845934
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876845929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MeshFormatVersion: 2
+  m_Faces:
+  - m_Indexes: 0400000006000000050000000400000007000000060000000400000008000000070000000900000008000000040000000300000009000000040000000100000003000000020000000300000001000000000000000c00000003000000000000000c0000000900000003000000090000000b0000000a0000000b000000090000000c000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: 0
+    m_TextureGroup: -1
+  - m_Indexes: 1700000012000000180000001900000018000000120000001300000012000000170000001600000013000000170000001600000014000000130000001500000013000000140000000d00000012000000130000000d000000110000001200000010000000110000000d0000000e000000100000000d0000000f0000000e0000000d000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: 0
+    m_TextureGroup: -1
+  - m_Indexes: 1a0000001b0000001c0000001b0000001d0000001c000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 1e0000001f000000200000001f0000002100000020000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 220000002300000024000000230000002500000024000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 260000002700000028000000270000002900000028000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 2a0000002b0000002c0000002b0000002d0000002c000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 2e0000002f000000300000002f0000003100000030000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 320000003300000034000000330000003500000034000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 360000003700000038000000370000003900000038000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 3a0000003b0000003c0000003b0000003d0000003c000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 3e0000003f000000400000003f0000004100000040000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 420000004300000044000000430000004500000044000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 460000004700000048000000470000004900000048000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 4a0000004b0000004c0000004b0000004d0000004c000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0, y: 0}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 7200000070000000710000006f00000070000000720000004e00000073000000740000004e0000004f00000073000000730000004f000000720000004f0000006f000000720000004f000000500000006f000000500000006e0000006f0000006d0000006e0000005000000050000000510000005200000052000000530000005000000050000000530000006d00000054000000550000005300000053000000550000006d0000006d000000550000006c000000550000006b0000006c00000055000000560000006b0000006b000000560000006a00000056000000570000006a0000006a00000057000000580000006a0000005800000069000000580000006800000069000000580000005900000068000000590000005a000000680000005a0000005b00000068000000680000005b00000067000000670000005b000000660000005b0000005c0000006600000065000000660000005c00000065000000630000006400000063000000650000005c0000005c00000062000000630000005d0000005e0000005c000000600000005e0000005f00000060000000610000005e0000005e000000610000005c00000061000000620000005c000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1.0000001}
+      m_Offset: {x: 14.533144, y: 18.089085}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 92000000960000009b000000920000009b00000098000000980000009b000000990000009a000000980000009900000092000000980000009700000094000000960000009200000092000000930000009400000095000000940000009300000092000000910000009300000091000000920000008f000000910000008f00000090000000900000008f0000008c0000008c0000008f0000008e0000008c0000008e0000008d0000008c0000008d0000008a0000008b0000008c0000008a0000008b0000008a000000880000008a000000890000008800000088000000890000008700000088000000870000008600000086000000870000008400000085000000860000008400000085000000840000007f0000007f00000084000000820000008200000084000000830000007f000000820000007d0000007d000000820000008100000081000000800000007d0000007d0000007e0000007f000000780000007e0000007d000000780000007d0000007c00000075000000780000007c000000750000007c0000007a0000007a0000007c000000790000007b0000007a00000079000000750000007600000078000000770000007600000075000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1.0000001}
+      m_Offset: {x: -14.533144, y: 18.089085}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 9c0000009d0000009e0000009d0000009f0000009e000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 0.737834, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: a0000000a1000000a2000000a1000000a3000000a2000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 18.089083, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: a4000000a5000000a6000000a5000000a7000000a6000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -14.533144, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: a8000000a9000000aa000000a9000000ab000000aa000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999998, y: 1}
+      m_Offset: {x: -17.309229, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: ac000000ad000000ae000000ad000000af000000ae000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000001, y: 1}
+      m_Offset: {x: 9.052443, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: b0000000b1000000b2000000b1000000b3000000b2000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999999, y: 1}
+      m_Offset: {x: 16.11016, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: b4000000b5000000b6000000b5000000b7000000b6000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.99999976, y: 1}
+      m_Offset: {x: -4.909155, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: b8000000b9000000ba000000b9000000bb000000ba000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.99999934, y: 1}
+      m_Offset: {x: 19.32172, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: bc000000bd000000be000000bd000000bf000000be000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.99999976, y: 1}
+      m_Offset: {x: -22.745016, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: c0000000c1000000c2000000c1000000c3000000c2000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -18.089083, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: c4000000c5000000c6000000c5000000c7000000c6000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000005, y: 1}
+      m_Offset: {x: 18.08909, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: c8000000c9000000ca000000c9000000cb000000ca000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999995, y: 1}
+      m_Offset: {x: 22.999222, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: cc000000cd000000ce000000cd000000cf000000ce000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000001, y: 1}
+      m_Offset: {x: 14.746183, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: d0000000d1000000d2000000d1000000d3000000d2000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000001, y: 1}
+      m_Offset: {x: -17.782452, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: d4000000d5000000d6000000d5000000d7000000d6000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.99999976, y: 1}
+      m_Offset: {x: -1.9223251, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: d8000000d9000000da000000d9000000db000000da000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -4.9091554, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: dc000000dd000000de000000dd000000df000000de000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000001, y: 1}
+      m_Offset: {x: -16.26095, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: e0000000e1000000e2000000e1000000e3000000e2000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000004, y: 1}
+      m_Offset: {x: 15.147903, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: e4000000e5000000e6000000e5000000e7000000e6000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -2.0582905, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: e8000000e9000000ea000000e9000000eb000000ea000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 6.115343, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: ec000000ed000000ee000000ed000000ef000000ee000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000001, y: 1}
+      m_Offset: {x: 15.244505, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: f0000000f1000000f2000000f1000000f3000000f2000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -14.533144, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: f4000000f5000000f6000000f5000000f7000000f6000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -21.756596, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: f8000000f9000000fa000000f9000000fb000000fa000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000032, y: 1}
+      m_Offset: {x: 21.073856, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: fc000000fd000000fe000000fd000000ff000000fe000000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 22.432472, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 000100000101000002010000010100000301000002010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999997, y: 1}
+      m_Offset: {x: 4.538786, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 040100000501000006010000050100000701000006010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000005, y: 1}
+      m_Offset: {x: -4.909149, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 08010000090100000a010000090100000b0100000a010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999998, y: 1}
+      m_Offset: {x: -19.507622, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 0c0100000d0100000e0100000d0100000f0100000e010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999982, y: 1}
+      m_Offset: {x: 13.297722, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 100100001101000012010000110100001301000012010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 18.089083, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 140100001501000016010000150100001701000016010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999991, y: 1}
+      m_Offset: {x: 2.51441, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 18010000190100001a010000190100001b0100001a010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 18.089083, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 1c0100001d0100001e0100001d0100001f0100001e010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -14.533144, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 200100002101000022010000210100002301000022010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 23.200314, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 240100002501000026010000250100002701000026010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000002, y: 1}
+      m_Offset: {x: 17.897047, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 28010000290100002a010000290100002b0100002a010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.99999994, y: 1}
+      m_Offset: {x: 15.244517, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 2c0100002d0100002e0100002d0100002f0100002e010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.000001, y: 1}
+      m_Offset: {x: -2.5144463, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 300100003101000032010000310100003301000032010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000001, y: 1}
+      m_Offset: {x: -18.089085, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 340100003501000036010000350100003701000036010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000002, y: 1}
+      m_Offset: {x: -23.192303, y: -1.8600004}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 390100003a01000038010000380100003a0100003b0100003d0100003e0100003f0100003c0100003d0100003b0100003b0100003d0100003f0100003f010000380100003b010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.99999976, y: 1.0000001}
+      m_Offset: {x: -33.316383, y: 20.23936}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 430100004201000046010000460100004401000043010000430100004401000047010000460100004501000044010000430100004101000042010000420100004101000040010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999998, y: 1.0000001}
+      m_Offset: {x: 33.316383, y: 20.23936}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 48010000490100004a010000490100004b0100004a010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: 33.31639, y: -0.07000065}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 4c0100004d0100004e0100004d0100004f0100004e010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000006, y: 1}
+      m_Offset: {x: 15.490249, y: -0.9214163}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 500100005101000052010000510100005301000052010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999991, y: 1}
+      m_Offset: {x: 37.8696, y: -0.07000065}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 540100005501000056010000550100005701000056010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1}
+      m_Offset: {x: -33.31639, y: -0.07000065}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 58010000590100005a010000590100005b0100005a010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.99999917, y: 1.0000001}
+      m_Offset: {x: -37.923767, y: -0.16649628}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 5c0100005d0100005e0100005d0100005f0100005e010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 0.9999996, y: 1}
+      m_Offset: {x: -12.124083, y: -0.07000065}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 600100006101000062010000610100006301000062010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1.0000004, y: 1}
+      m_Offset: {x: 21.608799, y: -0.07000065}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  - m_Indexes: 640100006501000066010000650100006701000066010000
+    m_SmoothingGroup: 0
+    m_Uv:
+      m_UseWorldSpace: 0
+      m_FlipU: 0
+      m_FlipV: 0
+      m_SwapUV: 0
+      m_Fill: 1
+      m_Scale: {x: 1, y: 1.0000002}
+      m_Offset: {x: -20.197617, y: -0.63693905}
+      m_Rotation: 0
+      m_Anchor: 9
+    m_Material: {fileID: 0}
+    m_SubmeshIndex: 0
+    m_ManualUV: 0
+    elementGroup: -1
+    m_TextureGroup: -1
+  m_SharedVertices:
+  - m_Vertices: 000000003d00000040000000
+  - m_Vertices: 160000003b0000003e000000
+  - m_Vertices: 01000000390000003c000000
+  - m_Vertices: 14000000370000003a000000
+  - m_Vertices: 020000003500000038000000
+  - m_Vertices: 150000003300000036000000
+  - m_Vertices: 030000003100000034000000
+  - m_Vertices: 130000002f00000032000000
+  - m_Vertices: 040000002100000030000000
+  - m_Vertices: 0d0000001f0000002e000000
+  - m_Vertices: 050000001d00000020000000
+  - m_Vertices: 0f0000001b0000001e000000
+  - m_Vertices: 060000001c00000025000000
+  - m_Vertices: 0e0000001a00000023000000
+  - m_Vertices: 070000002400000029000000
+  - m_Vertices: 100000002200000027000000
+  - m_Vertices: 08000000280000002d000000
+  - m_Vertices: 11000000260000002b000000
+  - m_Vertices: 090000002c00000049000000
+  - m_Vertices: 120000002a00000047000000
+  - m_Vertices: 0a0000004500000048000000
+  - m_Vertices: 190000004300000046000000
+  - m_Vertices: 0b000000440000004d000000
+  - m_Vertices: 18000000420000004b000000
+  - m_Vertices: 0c000000410000004c000000
+  - m_Vertices: 170000003f0000004a000000
+  - m_Vertices: 4e000000af000000b2000000
+  - m_Vertices: 79000000ad000000b0000000
+  - m_Vertices: 4f000000b3000000ba000000
+  - m_Vertices: 7c000000b1000000b8000000
+  - m_Vertices: 50000000bb000000c6000000
+  - m_Vertices: 7d000000b9000000c4000000
+  - m_Vertices: 51000000c7000000ca000000
+  - m_Vertices: 80000000c5000000c8000000
+  - m_Vertices: 52000000cb000000ce000000
+  - m_Vertices: 81000000c9000000cc000000
+  - m_Vertices: 53000000cf000000d6000000
+  - m_Vertices: 82000000cd000000d4000000
+  - m_Vertices: 54000000d2000000d7000000
+  - m_Vertices: 83000000d0000000d5000000
+  - m_Vertices: 55000000d3000000e2000000
+  - m_Vertices: 84000000d1000000e0000000
+  - m_Vertices: 56000000e3000000ea000000
+  - m_Vertices: 87000000e1000000e8000000
+  - m_Vertices: 57000000eb000000ee000000
+  - m_Vertices: 89000000e9000000ec000000
+  - m_Vertices: 58000000ef000000fa000000
+  - m_Vertices: 8a000000ed000000f8000000
+  - m_Vertices: 59000000fb000000fe000000
+  - m_Vertices: 8d000000f9000000fc000000
+  - m_Vertices: 5a000000ff00000002010000
+  - m_Vertices: 8e000000fd00000000010000
+  - m_Vertices: 5b000000030100000e010000
+  - m_Vertices: 8f000000010100000c010000
+  - m_Vertices: 5c0000000f01000026010000
+  - m_Vertices: 920000000d01000024010000
+  - m_Vertices: 5d0000002201000027010000
+  - m_Vertices: 970000002001000025010000
+  - m_Vertices: 5e000000230100002a010000
+  - m_Vertices: 980000002101000028010000
+  - m_Vertices: 5f0000002b0100002e010000
+  - m_Vertices: 9a000000290100002c010000
+  - m_Vertices: 600000002f01000032010000
+  - m_Vertices: 990000002d01000030010000
+  - m_Vertices: 610000003301000036010000
+  - m_Vertices: 9b0000003101000034010000
+  - m_Vertices: 620000001e01000037010000
+  - m_Vertices: 960000001c01000035010000
+  - m_Vertices: 63000000160100001f010000
+  - m_Vertices: 94000000140100001d010000
+  - m_Vertices: 64000000170100001a010000
+  - m_Vertices: 950000001501000018010000
+  - m_Vertices: 65000000120100001b010000
+  - m_Vertices: 930000001001000019010000
+  - m_Vertices: 660000000a01000013010000
+  - m_Vertices: 910000000801000011010000
+  - m_Vertices: 67000000060100000b010000
+  - m_Vertices: 900000000401000009010000
+  - m_Vertices: 68000000f600000007010000
+  - m_Vertices: 8c000000f400000005010000
+  - m_Vertices: 69000000f2000000f7000000
+  - m_Vertices: 8b000000f0000000f5000000
+  - m_Vertices: 6a000000e6000000f3000000
+  - m_Vertices: 88000000e4000000f1000000
+  - m_Vertices: 6b000000de000000e7000000
+  - m_Vertices: 86000000dc000000e5000000
+  - m_Vertices: 6c000000da000000df000000
+  - m_Vertices: 85000000d8000000dd000000
+  - m_Vertices: 6d000000c2000000db000000
+  - m_Vertices: 7f000000c0000000d9000000
+  - m_Vertices: 6e000000be000000c3000000
+  - m_Vertices: 7e000000bc000000c1000000
+  - m_Vertices: 6f000000a6000000bf000000
+  - m_Vertices: 78000000a4000000bd000000
+  - m_Vertices: 700000009e000000a7000000
+  - m_Vertices: 760000009c000000a5000000
+  - m_Vertices: 710000009f000000a2000000
+  - m_Vertices: 770000009d000000a0000000
+  - m_Vertices: 72000000a3000000b6000000
+  - m_Vertices: 75000000a1000000b4000000
+  - m_Vertices: 73000000aa000000b7000000
+  - m_Vertices: 7a000000a8000000b5000000
+  - m_Vertices: 74000000ab000000ae000000
+  - m_Vertices: 7b000000a9000000ac000000
+  - m_Vertices: 380100004e01000067010000
+  - m_Vertices: 420100004c01000065010000
+  - m_Vertices: 390100004a0100004f010000
+  - m_Vertices: 40010000480100004d010000
+  - m_Vertices: 3a0100004b01000052010000
+  - m_Vertices: 410100004901000050010000
+  - m_Vertices: 3b0100005301000062010000
+  - m_Vertices: 430100005101000060010000
+  - m_Vertices: 3c0100005e01000063010000
+  - m_Vertices: 470100005c01000061010000
+  - m_Vertices: 3d010000560100005f010000
+  - m_Vertices: 44010000540100005d010000
+  - m_Vertices: 3e010000570100005a010000
+  - m_Vertices: 450100005501000058010000
+  - m_Vertices: 3f0100005b01000066010000
+  - m_Vertices: 460100005901000064010000
+  m_SharedTextures: []
+  m_Positions:
+  - {x: 0.000000629742, y: 10, z: -0.00000045432603}
+  - {x: -0.06638845, y: 10, z: 2.7393591}
+  - {x: -1.5663885, y: 9.999999, z: 4.2393594}
+  - {x: -2.5663884, y: 9.999999, z: 4.2393594}
+  - {x: -3.0663884, y: 9.999999, z: 5.4893594}
+  - {x: -2.6825907, y: 9.999999, z: 5.5761704}
+  - {x: -3.7676833, y: 10.000001, z: 8.319045}
+  - {x: -4.4006543, y: 10.000001, z: 8.077913}
+  - {x: -3.3758442, y: 9.999999, z: 5.274756}
+  - {x: -2.9538643, y: 9.999999, z: 4.280088}
+  - {x: -4.491079, y: 9.999999, z: 4.3403707}
+  - {x: -5.998153, y: 10, z: 2.8332975}
+  - {x: -6.028294, y: 10, z: -0.12056623}
+  - {x: -3.066389, y: -0.0000009536743, z: 5.48936}
+  - {x: -3.767684, y: 0.0000009536743, z: 8.319045}
+  - {x: -2.6825914, y: -0.0000009536743, z: 5.576171}
+  - {x: -4.400655, y: 0.0000009536743, z: 8.077913}
+  - {x: -3.375845, y: -0.0000009536743, z: 5.2747564}
+  - {x: -2.953865, y: -0.0000009536743, z: 4.2800884}
+  - {x: -2.566389, y: -0.0000009536743, z: 4.23936}
+  - {x: -0.066389084, y: 0, z: 2.7393596}
+  - {x: -1.5663891, y: -0.0000009536743, z: 4.23936}
+  - {x: 0, y: 0, z: 0}
+  - {x: -6.0282946, y: 0, z: -0.12056577}
+  - {x: -5.9981537, y: 0, z: 2.833298}
+  - {x: -4.4910793, y: -0.0000009536743, z: 4.340371}
+  - {x: -3.767684, y: 0.0000009536743, z: 8.319045}
+  - {x: -2.6825914, y: -0.0000009536743, z: 5.576171}
+  - {x: -3.7676833, y: 10.000001, z: 8.319045}
+  - {x: -2.6825907, y: 9.999999, z: 5.5761704}
+  - {x: -2.6825914, y: -0.0000009536743, z: 5.576171}
+  - {x: -3.066389, y: -0.0000009536743, z: 5.48936}
+  - {x: -2.6825907, y: 9.999999, z: 5.5761704}
+  - {x: -3.0663884, y: 9.999999, z: 5.4893594}
+  - {x: -4.400655, y: 0.0000009536743, z: 8.077913}
+  - {x: -3.767684, y: 0.0000009536743, z: 8.319045}
+  - {x: -4.4006543, y: 10.000001, z: 8.077913}
+  - {x: -3.7676833, y: 10.000001, z: 8.319045}
+  - {x: -3.375845, y: -0.0000009536743, z: 5.2747564}
+  - {x: -4.400655, y: 0.0000009536743, z: 8.077913}
+  - {x: -3.3758442, y: 9.999999, z: 5.274756}
+  - {x: -4.4006543, y: 10.000001, z: 8.077913}
+  - {x: -2.953865, y: -0.0000009536743, z: 4.2800884}
+  - {x: -3.375845, y: -0.0000009536743, z: 5.2747564}
+  - {x: -2.9538643, y: 9.999999, z: 4.280088}
+  - {x: -3.3758442, y: 9.999999, z: 5.274756}
+  - {x: -3.066389, y: -0.0000009536743, z: 5.48936}
+  - {x: -2.566389, y: -0.0000009536743, z: 4.23936}
+  - {x: -3.0663884, y: 9.999999, z: 5.4893594}
+  - {x: -2.5663884, y: 9.999999, z: 4.2393594}
+  - {x: -2.566389, y: -0.0000009536743, z: 4.23936}
+  - {x: -1.5663891, y: -0.0000009536743, z: 4.23936}
+  - {x: -2.5663884, y: 9.999999, z: 4.2393594}
+  - {x: -1.5663885, y: 9.999999, z: 4.2393594}
+  - {x: -1.5663891, y: -0.0000009536743, z: 4.23936}
+  - {x: -0.066389084, y: 0, z: 2.7393596}
+  - {x: -1.5663885, y: 9.999999, z: 4.2393594}
+  - {x: -0.06638845, y: 10, z: 2.7393591}
+  - {x: -0.066389084, y: 0, z: 2.7393596}
+  - {x: 0, y: 0, z: 0}
+  - {x: -0.06638845, y: 10, z: 2.7393591}
+  - {x: 0.000000629742, y: 10, z: -0.00000045432603}
+  - {x: 0, y: 0, z: 0}
+  - {x: -6.0282946, y: 0, z: -0.12056577}
+  - {x: 0.000000629742, y: 10, z: -0.00000045432603}
+  - {x: -6.028294, y: 10, z: -0.12056623}
+  - {x: -5.9981537, y: 0, z: 2.833298}
+  - {x: -4.4910793, y: -0.0000009536743, z: 4.340371}
+  - {x: -5.998153, y: 10, z: 2.8332975}
+  - {x: -4.491079, y: 9.999999, z: 4.3403707}
+  - {x: -4.4910793, y: -0.0000009536743, z: 4.340371}
+  - {x: -2.953865, y: -0.0000009536743, z: 4.2800884}
+  - {x: -4.491079, y: 9.999999, z: 4.3403707}
+  - {x: -2.9538643, y: 9.999999, z: 4.280088}
+  - {x: -6.0282946, y: 0, z: -0.12056577}
+  - {x: -5.9981537, y: 0, z: 2.833298}
+  - {x: -6.028294, y: 10, z: -0.12056623}
+  - {x: -5.998153, y: 10, z: 2.8332975}
+  - {x: 14.533144, y: 8.139999, z: 18.089083}
+  - {x: 10.683611, y: 8.139999, z: 17.739359}
+  - {x: 10.554068, y: 8.139999, z: 16.30343}
+  - {x: 10.554068, y: 8.139999, z: 14.336238}
+  - {x: 9.051846, y: 8.139999, z: 12.905551}
+  - {x: 3.0071936, y: 8.139999, z: 12.834017}
+  - {x: 1.5765066, y: 8.139999, z: 14.19317}
+  - {x: 1.5049715, y: 8.139999, z: 17.626816}
+  - {x: -1.6067715, y: 8.139999, z: 17.519514}
+  - {x: -2.4294186, y: 8.139999, z: 17.877186}
+  - {x: -3.323597, y: 8.139999, z: 17.84142}
+  - {x: -3.4308987, y: 8.139999, z: 17.412214}
+  - {x: -3.7170353, y: 8.139999, z: 16.768404}
+  - {x: -6.328039, y: 8.139999, z: 18.127558}
+  - {x: -6.8645477, y: 8.139999, z: 18.163324}
+  - {x: -6.816389, y: 8.139999, z: 14.48936}
+  - {x: -8.066389, y: 8.139999, z: 12.98936}
+  - {x: -14.316389, y: 8.139999, z: 12.73936}
+  - {x: -15.816389, y: 8.139999, z: 14.23936}
+  - {x: -15.816389, y: 8.139999, z: 20.239359}
+  - {x: -14.316389, y: 8.139999, z: 21.989359}
+  - {x: -8.316389, y: 8.139999, z: 21.989359}
+  - {x: -6.816389, y: 8.139999, z: 20.489359}
+  - {x: -6.816389, y: 8.139999, z: 18.989359}
+  - {x: -6.816389, y: 8.139999, z: 18.489359}
+  - {x: -6.066389, y: 8.139999, z: 18.739359}
+  - {x: -4.066389, y: 8.139999, z: 17.739359}
+  - {x: -3.816389, y: 8.139999, z: 18.489359}
+  - {x: -2.066389, y: 8.139999, z: 18.489359}
+  - {x: -1.3163891, y: 8.139999, z: 17.989359}
+  - {x: 1.1836109, y: 8.139999, z: 18.239359}
+  - {x: 1.6836109, y: 8.139999, z: 17.989359}
+  - {x: 1.6836109, y: 8.139999, z: 20.489359}
+  - {x: 3.183611, y: 8.139999, z: 21.739359}
+  - {x: 8.933611, y: 8.139999, z: 21.739359}
+  - {x: 10.683611, y: 8.139999, z: 20.239359}
+  - {x: 10.683611, y: 8.139999, z: 18.489359}
+  - {x: 11.183611, y: 8.139999, z: 18.239359}
+  - {x: 14.183611, y: 8.139999, z: 18.739359}
+  - {x: 10.683611, y: -1.8600001, z: 18.489359}
+  - {x: 8.933611, y: -1.8600001, z: 21.739359}
+  - {x: 10.683611, y: -1.8600001, z: 20.239359}
+  - {x: 3.183611, y: -1.8600001, z: 21.739359}
+  - {x: 14.533144, y: -1.8600001, z: 18.089083}
+  - {x: 11.183611, y: -1.8600001, z: 18.239359}
+  - {x: 14.183611, y: -1.8600001, z: 18.739359}
+  - {x: 10.683611, y: -1.8600001, z: 17.739359}
+  - {x: 10.554068, y: -1.8600001, z: 16.30343}
+  - {x: 1.6836109, y: -1.8600001, z: 20.489359}
+  - {x: 1.6836109, y: -1.8600001, z: 17.989359}
+  - {x: 10.554068, y: -1.8600001, z: 14.336238}
+  - {x: 9.051846, y: -1.8600001, z: 12.905551}
+  - {x: 3.0071936, y: -1.8600001, z: 12.834017}
+  - {x: 1.5765066, y: -1.8600001, z: 14.19317}
+  - {x: 1.5049715, y: -1.8600001, z: 17.626816}
+  - {x: 1.1836109, y: -1.8600001, z: 18.239359}
+  - {x: -1.3163891, y: -1.8600001, z: 17.989359}
+  - {x: -1.6067715, y: -1.8600001, z: 17.519514}
+  - {x: -2.066389, y: -1.8600001, z: 18.489359}
+  - {x: -2.4294186, y: -1.8600001, z: 17.877186}
+  - {x: -3.323597, y: -1.8600001, z: 17.84142}
+  - {x: -3.816389, y: -1.8600001, z: 18.489359}
+  - {x: -4.066389, y: -1.8600001, z: 17.739359}
+  - {x: -3.4308987, y: -1.8600001, z: 17.412214}
+  - {x: -3.7170353, y: -1.8600001, z: 16.768404}
+  - {x: -6.328039, y: -1.8600001, z: 18.127558}
+  - {x: -6.066389, y: -1.8600001, z: 18.739359}
+  - {x: -6.816389, y: -1.8600001, z: 18.489359}
+  - {x: -6.8645477, y: -1.8600001, z: 18.163324}
+  - {x: -6.816389, y: -1.8600001, z: 18.989359}
+  - {x: -8.316389, y: -1.8600001, z: 21.989359}
+  - {x: -6.816389, y: -1.8600001, z: 20.489359}
+  - {x: -14.316389, y: -1.8600001, z: 21.989359}
+  - {x: -6.816389, y: -1.8600001, z: 14.48936}
+  - {x: -8.066389, y: -1.8600001, z: 12.98936}
+  - {x: -15.816389, y: -1.8600001, z: 14.23936}
+  - {x: -14.316389, y: -1.8600001, z: 12.73936}
+  - {x: -15.816389, y: -1.8600001, z: 20.239359}
+  - {x: 8.933611, y: -1.8600001, z: 21.739359}
+  - {x: 10.683611, y: -1.8600001, z: 20.239359}
+  - {x: 8.933611, y: 8.139999, z: 21.739359}
+  - {x: 10.683611, y: 8.139999, z: 20.239359}
+  - {x: 10.683611, y: -1.8600001, z: 20.239359}
+  - {x: 10.683611, y: -1.8600001, z: 18.489359}
+  - {x: 10.683611, y: 8.139999, z: 20.239359}
+  - {x: 10.683611, y: 8.139999, z: 18.489359}
+  - {x: 3.183611, y: -1.8600001, z: 21.739359}
+  - {x: 8.933611, y: -1.8600001, z: 21.739359}
+  - {x: 3.183611, y: 8.139999, z: 21.739359}
+  - {x: 8.933611, y: 8.139999, z: 21.739359}
+  - {x: 11.183611, y: -1.8600001, z: 18.239359}
+  - {x: 14.183611, y: -1.8600001, z: 18.739359}
+  - {x: 11.183611, y: 8.139999, z: 18.239359}
+  - {x: 14.183611, y: 8.139999, z: 18.739359}
+  - {x: 14.183611, y: -1.8600001, z: 18.739359}
+  - {x: 14.533144, y: -1.8600001, z: 18.089083}
+  - {x: 14.183611, y: 8.139999, z: 18.739359}
+  - {x: 14.533144, y: 8.139999, z: 18.089083}
+  - {x: 14.533144, y: -1.8600001, z: 18.089083}
+  - {x: 10.683611, y: -1.8600001, z: 17.739359}
+  - {x: 14.533144, y: 8.139999, z: 18.089083}
+  - {x: 10.683611, y: 8.139999, z: 17.739359}
+  - {x: 10.683611, y: -1.8600001, z: 18.489359}
+  - {x: 11.183611, y: -1.8600001, z: 18.239359}
+  - {x: 10.683611, y: 8.139999, z: 18.489359}
+  - {x: 11.183611, y: 8.139999, z: 18.239359}
+  - {x: 10.683611, y: -1.8600001, z: 17.739359}
+  - {x: 10.554068, y: -1.8600001, z: 16.30343}
+  - {x: 10.683611, y: 8.139999, z: 17.739359}
+  - {x: 10.554068, y: 8.139999, z: 16.30343}
+  - {x: 1.6836109, y: -1.8600001, z: 20.489359}
+  - {x: 3.183611, y: -1.8600001, z: 21.739359}
+  - {x: 1.6836109, y: 8.139999, z: 20.489359}
+  - {x: 3.183611, y: 8.139999, z: 21.739359}
+  - {x: 1.6836109, y: -1.8600001, z: 17.989359}
+  - {x: 1.6836109, y: -1.8600001, z: 20.489359}
+  - {x: 1.6836109, y: 8.139999, z: 17.989359}
+  - {x: 1.6836109, y: 8.139999, z: 20.489359}
+  - {x: 10.554068, y: -1.8600001, z: 16.30343}
+  - {x: 10.554068, y: -1.8600001, z: 14.336238}
+  - {x: 10.554068, y: 8.139999, z: 16.30343}
+  - {x: 10.554068, y: 8.139999, z: 14.336238}
+  - {x: 10.554068, y: -1.8600001, z: 14.336238}
+  - {x: 9.051846, y: -1.8600001, z: 12.905551}
+  - {x: 10.554068, y: 8.139999, z: 14.336238}
+  - {x: 9.051846, y: 8.139999, z: 12.905551}
+  - {x: 9.051846, y: -1.8600001, z: 12.905551}
+  - {x: 3.0071936, y: -1.8600001, z: 12.834017}
+  - {x: 9.051846, y: 8.139999, z: 12.905551}
+  - {x: 3.0071936, y: 8.139999, z: 12.834017}
+  - {x: 1.5765066, y: -1.8600001, z: 14.19317}
+  - {x: 1.5049715, y: -1.8600001, z: 17.626816}
+  - {x: 1.5765066, y: 8.139999, z: 14.19317}
+  - {x: 1.5049715, y: 8.139999, z: 17.626816}
+  - {x: 3.0071936, y: -1.8600001, z: 12.834017}
+  - {x: 1.5765066, y: -1.8600001, z: 14.19317}
+  - {x: 3.0071936, y: 8.139999, z: 12.834017}
+  - {x: 1.5765066, y: 8.139999, z: 14.19317}
+  - {x: 1.1836109, y: -1.8600001, z: 18.239359}
+  - {x: 1.6836109, y: -1.8600001, z: 17.989359}
+  - {x: 1.1836109, y: 8.139999, z: 18.239359}
+  - {x: 1.6836109, y: 8.139999, z: 17.989359}
+  - {x: -1.3163891, y: -1.8600001, z: 17.989359}
+  - {x: 1.1836109, y: -1.8600001, z: 18.239359}
+  - {x: -1.3163891, y: 8.139999, z: 17.989359}
+  - {x: 1.1836109, y: 8.139999, z: 18.239359}
+  - {x: 1.5049715, y: -1.8600001, z: 17.626816}
+  - {x: -1.6067715, y: -1.8600001, z: 17.519514}
+  - {x: 1.5049715, y: 8.139999, z: 17.626816}
+  - {x: -1.6067715, y: 8.139999, z: 17.519514}
+  - {x: -2.066389, y: -1.8600001, z: 18.489359}
+  - {x: -1.3163891, y: -1.8600001, z: 17.989359}
+  - {x: -2.066389, y: 8.139999, z: 18.489359}
+  - {x: -1.3163891, y: 8.139999, z: 17.989359}
+  - {x: -1.6067715, y: -1.8600001, z: 17.519514}
+  - {x: -2.4294186, y: -1.8600001, z: 17.877186}
+  - {x: -1.6067715, y: 8.139999, z: 17.519514}
+  - {x: -2.4294186, y: 8.139999, z: 17.877186}
+  - {x: -2.4294186, y: -1.8600001, z: 17.877186}
+  - {x: -3.323597, y: -1.8600001, z: 17.84142}
+  - {x: -2.4294186, y: 8.139999, z: 17.877186}
+  - {x: -3.323597, y: 8.139999, z: 17.84142}
+  - {x: -3.816389, y: -1.8600001, z: 18.489359}
+  - {x: -2.066389, y: -1.8600001, z: 18.489359}
+  - {x: -3.816389, y: 8.139999, z: 18.489359}
+  - {x: -2.066389, y: 8.139999, z: 18.489359}
+  - {x: -4.066389, y: -1.8600001, z: 17.739359}
+  - {x: -3.816389, y: -1.8600001, z: 18.489359}
+  - {x: -4.066389, y: 8.139999, z: 17.739359}
+  - {x: -3.816389, y: 8.139999, z: 18.489359}
+  - {x: -3.323597, y: -1.8600001, z: 17.84142}
+  - {x: -3.4308987, y: -1.8600001, z: 17.412214}
+  - {x: -3.323597, y: 8.139999, z: 17.84142}
+  - {x: -3.4308987, y: 8.139999, z: 17.412214}
+  - {x: -3.4308987, y: -1.8600001, z: 17.412214}
+  - {x: -3.7170353, y: -1.8600001, z: 16.768404}
+  - {x: -3.4308987, y: 8.139999, z: 17.412214}
+  - {x: -3.7170353, y: 8.139999, z: 16.768404}
+  - {x: -3.7170353, y: -1.8600001, z: 16.768404}
+  - {x: -6.328039, y: -1.8600001, z: 18.127558}
+  - {x: -3.7170353, y: 8.139999, z: 16.768404}
+  - {x: -6.328039, y: 8.139999, z: 18.127558}
+  - {x: -6.066389, y: -1.8600001, z: 18.739359}
+  - {x: -4.066389, y: -1.8600001, z: 17.739359}
+  - {x: -6.066389, y: 8.139999, z: 18.739359}
+  - {x: -4.066389, y: 8.139999, z: 17.739359}
+  - {x: -6.816389, y: -1.8600001, z: 18.489359}
+  - {x: -6.066389, y: -1.8600001, z: 18.739359}
+  - {x: -6.816389, y: 8.139999, z: 18.489359}
+  - {x: -6.066389, y: 8.139999, z: 18.739359}
+  - {x: -6.328039, y: -1.8600001, z: 18.127558}
+  - {x: -6.8645477, y: -1.8600001, z: 18.163324}
+  - {x: -6.328039, y: 8.139999, z: 18.127558}
+  - {x: -6.8645477, y: 8.139999, z: 18.163324}
+  - {x: -6.816389, y: -1.8600001, z: 18.989359}
+  - {x: -6.816389, y: -1.8600001, z: 18.489359}
+  - {x: -6.816389, y: 8.139999, z: 18.989359}
+  - {x: -6.816389, y: 8.139999, z: 18.489359}
+  - {x: -8.316389, y: -1.8600001, z: 21.989359}
+  - {x: -6.816389, y: -1.8600001, z: 20.489359}
+  - {x: -8.316389, y: 8.139999, z: 21.989359}
+  - {x: -6.816389, y: 8.139999, z: 20.489359}
+  - {x: -6.816389, y: -1.8600001, z: 20.489359}
+  - {x: -6.816389, y: -1.8600001, z: 18.989359}
+  - {x: -6.816389, y: 8.139999, z: 20.489359}
+  - {x: -6.816389, y: 8.139999, z: 18.989359}
+  - {x: -14.316389, y: -1.8600001, z: 21.989359}
+  - {x: -8.316389, y: -1.8600001, z: 21.989359}
+  - {x: -14.316389, y: 8.139999, z: 21.989359}
+  - {x: -8.316389, y: 8.139999, z: 21.989359}
+  - {x: -6.816389, y: -1.8600001, z: 14.48936}
+  - {x: -8.066389, y: -1.8600001, z: 12.98936}
+  - {x: -6.816389, y: 8.139999, z: 14.48936}
+  - {x: -8.066389, y: 8.139999, z: 12.98936}
+  - {x: -6.8645477, y: -1.8600001, z: 18.163324}
+  - {x: -6.816389, y: -1.8600001, z: 14.48936}
+  - {x: -6.8645477, y: 8.139999, z: 18.163324}
+  - {x: -6.816389, y: 8.139999, z: 14.48936}
+  - {x: -8.066389, y: -1.8600001, z: 12.98936}
+  - {x: -14.316389, y: -1.8600001, z: 12.73936}
+  - {x: -8.066389, y: 8.139999, z: 12.98936}
+  - {x: -14.316389, y: 8.139999, z: 12.73936}
+  - {x: -14.316389, y: -1.8600001, z: 12.73936}
+  - {x: -15.816389, y: -1.8600001, z: 14.23936}
+  - {x: -14.316389, y: 8.139999, z: 12.73936}
+  - {x: -15.816389, y: 8.139999, z: 14.23936}
+  - {x: -15.816389, y: -1.8600001, z: 14.23936}
+  - {x: -15.816389, y: -1.8600001, z: 20.239359}
+  - {x: -15.816389, y: 8.139999, z: 14.23936}
+  - {x: -15.816389, y: 8.139999, z: 20.239359}
+  - {x: -15.816389, y: -1.8600001, z: 20.239359}
+  - {x: -14.316389, y: -1.8600001, z: 21.989359}
+  - {x: -15.816389, y: 8.139999, z: 20.239359}
+  - {x: -14.316389, y: 8.139999, z: 21.989359}
+  - {x: -32.81639, y: 9.929999, z: 20.739359}
+  - {x: -31.81639, y: 9.929999, z: 21.739359}
+  - {x: -25.81639, y: 9.929999, z: 21.739359}
+  - {x: -24.31639, y: 9.929999, z: 20.239359}
+  - {x: -24.06639, y: 9.929999, z: 14.23936}
+  - {x: -25.81639, y: 9.929999, z: 12.73936}
+  - {x: -31.56639, y: 9.929999, z: 12.73936}
+  - {x: -33.06639, y: 9.929999, z: 14.23936}
+  - {x: -31.81639, y: -0.07000017, z: 21.739359}
+  - {x: -25.81639, y: -0.07000017, z: 21.739359}
+  - {x: -33.228317, y: -0.07000017, z: 20.739359}
+  - {x: -24.31639, y: -0.07000017, z: 20.239359}
+  - {x: -25.81639, y: -0.07000017, z: 12.73936}
+  - {x: -31.718565, y: -0.07000017, z: 12.73936}
+  - {x: -33.236458, y: -0.07000017, z: 14.23936}
+  - {x: -24.06639, y: -0.07000017, z: 14.23936}
+  - {x: -31.81639, y: -0.07000017, z: 21.739359}
+  - {x: -25.81639, y: -0.07000017, z: 21.739359}
+  - {x: -31.81639, y: 9.929999, z: 21.739359}
+  - {x: -25.81639, y: 9.929999, z: 21.739359}
+  - {x: -33.228317, y: -0.07000017, z: 20.739359}
+  - {x: -31.81639, y: -0.07000017, z: 21.739359}
+  - {x: -32.81639, y: 9.929999, z: 20.739359}
+  - {x: -31.81639, y: 9.929999, z: 21.739359}
+  - {x: -25.81639, y: -0.07000017, z: 21.739359}
+  - {x: -24.31639, y: -0.07000017, z: 20.239359}
+  - {x: -25.81639, y: 9.929999, z: 21.739359}
+  - {x: -24.31639, y: 9.929999, z: 20.239359}
+  - {x: -25.81639, y: -0.07000017, z: 12.73936}
+  - {x: -31.718565, y: -0.07000017, z: 12.73936}
+  - {x: -25.81639, y: 9.929999, z: 12.73936}
+  - {x: -31.56639, y: 9.929999, z: 12.73936}
+  - {x: -31.718565, y: -0.07000017, z: 12.73936}
+  - {x: -33.236458, y: -0.07000017, z: 14.23936}
+  - {x: -31.56639, y: 9.929999, z: 12.73936}
+  - {x: -33.06639, y: 9.929999, z: 14.23936}
+  - {x: -24.06639, y: -0.07000017, z: 14.23936}
+  - {x: -25.81639, y: -0.07000017, z: 12.73936}
+  - {x: -24.06639, y: 9.929999, z: 14.23936}
+  - {x: -25.81639, y: 9.929999, z: 12.73936}
+  - {x: -24.31639, y: -0.07000017, z: 20.239359}
+  - {x: -24.06639, y: -0.07000017, z: 14.23936}
+  - {x: -24.31639, y: 9.929999, z: 20.239359}
+  - {x: -24.06639, y: 9.929999, z: 14.23936}
+  - {x: -33.236458, y: -0.07000017, z: 14.23936}
+  - {x: -33.228317, y: -0.07000017, z: 20.739359}
+  - {x: -33.06639, y: 9.929999, z: 14.23936}
+  - {x: -32.81639, y: 9.929999, z: 20.739359}
+  m_Textures0:
+  - {x: -1.8474111e-13, y: 1.1368684e-13}
+  - {x: -0.066389084, y: 2.7393596}
+  - {x: -1.5663891, y: 4.23936}
+  - {x: -2.566389, y: 4.23936}
+  - {x: -3.066389, y: 5.48936}
+  - {x: -2.6825914, y: 5.576171}
+  - {x: -3.767684, y: 8.319045}
+  - {x: -4.400655, y: 8.077913}
+  - {x: -3.375845, y: 5.2747564}
+  - {x: -2.953865, y: 4.2800884}
+  - {x: -4.4910793, y: 4.340371}
+  - {x: -5.9981537, y: 2.833298}
+  - {x: -6.0282946, y: -0.12056577}
+  - {x: 3.066389, y: 5.48936}
+  - {x: 3.767684, y: 8.319045}
+  - {x: 2.6825914, y: 5.576171}
+  - {x: 4.400655, y: 8.077913}
+  - {x: 3.375845, y: 5.2747564}
+  - {x: 2.953865, y: 4.2800884}
+  - {x: 2.566389, y: 4.23936}
+  - {x: 0.066389084, y: 2.7393596}
+  - {x: 1.5663891, y: 4.23936}
+  - {x: 0, y: 0}
+  - {x: 6.0282946, y: -0.12056577}
+  - {x: 5.9981537, y: 2.833298}
+  - {x: 4.4910793, y: 4.340371}
+  - {x: 9.121706, y: 0.0000009241962}
+  - {x: 6.1719966, y: -0.0000009831525}
+  - {x: 9.121706, y: 10.000001}
+  - {x: 6.171996, y: 9.999999}
+  - {x: -1.3862987, y: -0.0000013293117}
+  - {x: -1.7797917, y: -0.0000013293117}
+  - {x: -1.3862981, y: 9.999999}
+  - {x: -1.7797911, y: 9.999999}
+  - {x: 1.2366582, y: 0.00000079894005}
+  - {x: 0.5593129, y: 0.00000079894005}
+  - {x: 1.2366577, y: 10.000001}
+  - {x: 0.5593122, y: 10.000001}
+  - {x: -6.113208, y: -0.0000010227394}
+  - {x: -9.097822, y: 0.0000008846092}
+  - {x: -6.113207, y: 9.999999}
+  - {x: -9.097822, y: 10.000001}
+  - {x: -5.0938025, y: -0.0000010031486}
+  - {x: -6.17428, y: -0.0000010031486}
+  - {x: -5.093802, y: 9.999999}
+  - {x: -6.174279, y: 9.999999}
+  - {x: 6.235571, y: -0.0000009930426}
+  - {x: 4.88928, y: -0.0000009930426}
+  - {x: 6.2355704, y: 9.999999}
+  - {x: 4.8892794, y: 9.999999}
+  - {x: 2.566389, y: -0.0000011558227}
+  - {x: 1.5663891, y: -0.0000011558227}
+  - {x: 2.5663884, y: 9.999999}
+  - {x: 1.5663885, y: 9.999999}
+  - {x: 4.1052847, y: -0.0000009377422}
+  - {x: 1.9839641, y: 0.000000015932157}
+  - {x: 4.1052837, y: 9.999999}
+  - {x: 1.9839633, y: 10}
+  - {x: 2.740164, y: -3.52997e-17}
+  - {x: 0, y: 0}
+  - {x: 2.7401636, y: 10}
+  - {x: -0.00000046945013, y: 10}
+  - {x: 0, y: 0}
+  - {x: -6.0295005, y: -2.0970418e-16}
+  - {x: 0.0000006205314, y: 10}
+  - {x: -6.0295, y: 10}
+  - {x: 2.2378936, y: -0.00000042111637}
+  - {x: 0.10656942, y: -0.0000013747907}
+  - {x: 2.2378936, y: 10}
+  - {x: 0.10656942, y: 9.999999}
+  - {x: 4.657709, y: -0.0000011441614}
+  - {x: 3.1193135, y: -0.0000011441614}
+  - {x: 4.6577086, y: 9.999999}
+  - {x: 3.1193128, y: 9.999999}
+  - {x: 0.1820683, y: -0.0000002901577}
+  - {x: -2.7719493, y: -0.0000002901577}
+  - {x: 0.18206875, y: 10}
+  - {x: -2.7719488, y: 10}
+  - {x: 0, y: 0}
+  - {x: -3.849533, y: -0.34972382}
+  - {x: -3.9790764, y: -1.7856522}
+  - {x: -3.9790764, y: -3.7528458}
+  - {x: -5.4812984, y: -5.1835327}
+  - {x: -11.52595, y: -5.255066}
+  - {x: -12.956637, y: -3.895914}
+  - {x: -13.0281725, y: -0.46226692}
+  - {x: -16.139915, y: -0.56956863}
+  - {x: -16.962563, y: -0.2118969}
+  - {x: -17.85674, y: -0.2476635}
+  - {x: -17.964043, y: -0.67686844}
+  - {x: -18.25018, y: -1.3206787}
+  - {x: -20.861183, y: 0.038475037}
+  - {x: -21.397692, y: 0.07424164}
+  - {x: -21.349533, y: -3.5997229}
+  - {x: -22.599533, y: -5.099724}
+  - {x: -28.849533, y: -5.349724}
+  - {x: -30.349533, y: -3.8497238}
+  - {x: -30.349533, y: 2.1502762}
+  - {x: -28.849533, y: 3.9002762}
+  - {x: -22.849533, y: 3.9002762}
+  - {x: -21.349533, y: 2.4002762}
+  - {x: -21.349533, y: 0.9002762}
+  - {x: -21.349533, y: 0.40027618}
+  - {x: -20.599533, y: 0.6502762}
+  - {x: -18.599533, y: -0.34972382}
+  - {x: -18.349533, y: 0.40027618}
+  - {x: -16.599533, y: 0.40027618}
+  - {x: -15.849533, y: -0.099723816}
+  - {x: -13.349533, y: 0.15027618}
+  - {x: -12.849533, y: -0.099723816}
+  - {x: -12.849533, y: 2.4002762}
+  - {x: -11.349533, y: 3.6502762}
+  - {x: -5.599533, y: 3.6502762}
+  - {x: -3.849533, y: 2.1502762}
+  - {x: -3.849533, y: 0.40027618}
+  - {x: -3.349533, y: 0.15027618}
+  - {x: -0.34953308, y: 0.6502762}
+  - {x: 3.849533, y: 0.40027618}
+  - {x: 5.599533, y: 3.6502762}
+  - {x: 3.849533, y: 2.1502762}
+  - {x: 11.349533, y: 3.6502762}
+  - {x: 0, y: 0}
+  - {x: 3.349533, y: 0.15027618}
+  - {x: 0.34953308, y: 0.6502762}
+  - {x: 3.849533, y: -0.34972382}
+  - {x: 3.9790764, y: -1.7856522}
+  - {x: 12.849533, y: 2.4002762}
+  - {x: 12.849533, y: -0.099723816}
+  - {x: 3.9790764, y: -3.7528458}
+  - {x: 5.4812984, y: -5.1835327}
+  - {x: 11.52595, y: -5.255066}
+  - {x: 12.956637, y: -3.895914}
+  - {x: 13.0281725, y: -0.46226692}
+  - {x: 13.349533, y: 0.15027618}
+  - {x: 15.849533, y: -0.099723816}
+  - {x: 16.139915, y: -0.56956863}
+  - {x: 16.599533, y: 0.40027618}
+  - {x: 16.962563, y: -0.2118969}
+  - {x: 17.85674, y: -0.2476635}
+  - {x: 18.349533, y: 0.40027618}
+  - {x: 18.599533, y: -0.34972382}
+  - {x: 17.964043, y: -0.67686844}
+  - {x: 18.25018, y: -1.3206787}
+  - {x: 20.861183, y: 0.038475037}
+  - {x: 20.599533, y: 0.6502762}
+  - {x: 21.349533, y: 0.40027618}
+  - {x: 21.397692, y: 0.07424164}
+  - {x: 21.349533, y: 0.9002762}
+  - {x: 22.849533, y: 3.9002762}
+  - {x: 21.349533, y: 2.4002762}
+  - {x: 28.849533, y: 3.9002762}
+  - {x: 21.349533, y: -3.5997229}
+  - {x: 22.599533, y: -5.099724}
+  - {x: 30.349533, y: -3.8497238}
+  - {x: 28.849533, y: -5.349724}
+  - {x: 30.349533, y: 2.1502762}
+  - {x: 6.627051, y: 0.00000023841858}
+  - {x: 4.3221645, y: 0.00000023841858}
+  - {x: 6.627051, y: 10}
+  - {x: 4.3221645, y: 10}
+  - {x: 2.1502762, y: 0.00000023841858}
+  - {x: 0.40027618, y: 0.00000023841858}
+  - {x: 2.1502762, y: 10}
+  - {x: 0.40027618, y: 10}
+  - {x: 11.349533, y: 0.00000023841858}
+  - {x: 5.599533, y: 0.00000023841858}
+  - {x: 11.349533, y: 10}
+  - {x: 5.599533, y: 10}
+  - {x: 3.279254, y: 0}
+  - {x: 0.23787117, y: 0}
+  - {x: 3.279254, y: 10}
+  - {x: 0.23787117, y: 10}
+  - {x: 0.7382641, y: 0}
+  - {x: 0.0000009536743, y: 0}
+  - {x: 0.7382641, y: 10}
+  - {x: 0.0000009536743, y: 10}
+  - {x: 0, y: 0}
+  - {x: -3.865387, y: 0}
+  - {x: 0, y: 10}
+  - {x: -3.865387, y: 10}
+  - {x: 3.6221359, y: 0}
+  - {x: 3.063119, y: 0}
+  - {x: 3.6221359, y: 10}
+  - {x: 3.063119, y: 10}
+  - {x: -0.6941929, y: 0}
+  - {x: -2.135954, y: 0}
+  - {x: -0.6941929, y: 10}
+  - {x: -2.135954, y: 10}
+  - {x: 8.334666, y: 0}
+  - {x: 6.382103, y: 0}
+  - {x: 8.334666, y: 10}
+  - {x: 6.382103, y: 10}
+  - {x: 0.099723816, y: 0.00000023841858}
+  - {x: -2.4002762, y: 0.00000023841858}
+  - {x: 0.099723816, y: 10}
+  - {x: -2.4002762, y: 10}
+  - {x: -1.7856522, y: 0}
+  - {x: -3.7528458, y: 0}
+  - {x: -1.7856522, y: 10}
+  - {x: -3.7528458, y: 10}
+  - {x: -5.4695683, y: 0}
+  - {x: -7.5440655, y: 0}
+  - {x: -5.4695683, y: 10}
+  - {x: -7.5440655, y: 10}
+  - {x: -5.5422535, y: 0}
+  - {x: -11.587329, y: 0}
+  - {x: -5.5422535, y: 10}
+  - {x: -11.587329, y: 10}
+  - {x: 3.6251955, y: 0}
+  - {x: 0.19080353, y: 0}
+  - {x: 3.6251955, y: 10}
+  - {x: 0.19080353, y: 10}
+  - {x: -4.736883, y: 0}
+  - {x: -6.710246, y: 0}
+  - {x: -4.736883, y: 10}
+  - {x: -6.710246, y: 10}
+  - {x: 12.007391, y: 0.00000023841858}
+  - {x: 11.448374, y: 0.00000023841858}
+  - {x: 12.007391, y: 10}
+  - {x: 11.448374, y: 10}
+  - {x: 15.780798, y: 0}
+  - {x: 13.268329, y: 0}
+  - {x: 15.780798, y: 10}
+  - {x: 13.268329, y: 10}
+  - {x: -13.036364, y: 0}
+  - {x: -16.149958, y: 0}
+  - {x: -13.036364, y: 10}
+  - {x: -16.149958, y: 10}
+  - {x: 14.033681, y: 0.00000023841858}
+  - {x: 13.132294, y: 0.00000023841858}
+  - {x: 14.033681, y: 10}
+  - {x: 13.132294, y: 10}
+  - {x: -14.574338, y: 0.00000023841858}
+  - {x: -15.471376, y: 0.00000023841858}
+  - {x: -14.574338, y: 10}
+  - {x: -15.471376, y: 10}
+  - {x: -16.957478, y: 0}
+  - {x: -17.852371, y: 0}
+  - {x: -16.957478, y: 10}
+  - {x: -17.852371, y: 10}
+  - {x: 18.349533, y: 0.00000023841858}
+  - {x: 16.599533, y: 0.00000023841858}
+  - {x: 18.349533, y: 10}
+  - {x: 16.599533, y: 10}
+  - {x: 6.2134666, y: 0.00000023841858}
+  - {x: 5.4228973, y: 0.00000023841858}
+  - {x: 6.2134666, y: 10}
+  - {x: 5.4228973, y: 10}
+  - {x: -4.571184, y: 0}
+  - {x: -5.0135975, y: 0}
+  - {x: -4.571184, y: 10}
+  - {x: -5.0135975, y: 10}
+  - {x: -7.9143925, y: 0.00000023841858}
+  - {x: -8.618925, y: 0.00000023841858}
+  - {x: -7.9143925, y: 10}
+  - {x: -8.618925, y: 10}
+  - {x: -15.578426, y: 0}
+  - {x: -18.522003, y: 0}
+  - {x: -15.578426, y: 10}
+  - {x: -18.522003, y: 10}
+  - {x: 18.715595, y: 0}
+  - {x: 16.479527, y: 0}
+  - {x: 18.715595, y: 10}
+  - {x: 16.479527, y: 10}
+  - {x: 20.127367, y: 0}
+  - {x: 19.336798, y: 0}
+  - {x: 20.127367, y: 10}
+  - {x: 19.336798, y: 10}
+  - {x: -20.81754, y: 0}
+  - {x: -21.355238, y: 0}
+  - {x: -20.81754, y: 10}
+  - {x: -21.355238, y: 10}
+  - {x: 0.9002762, y: 0.00000023841858}
+  - {x: 0.40027618, y: 0.00000023841858}
+  - {x: 0.9002762, y: 10}
+  - {x: 0.40027618, y: 10}
+  - {x: 18.914968, y: 0}
+  - {x: 16.79365, y: 0}
+  - {x: 18.914968, y: 10}
+  - {x: 16.79365, y: 10}
+  - {x: 2.4002762, y: 0.00000023841858}
+  - {x: 0.9002762, y: 0.00000023841858}
+  - {x: 2.4002762, y: 10}
+  - {x: 0.9002762, y: 10}
+  - {x: 28.849533, y: 0.00000023841858}
+  - {x: 22.849533, y: 0.00000023841858}
+  - {x: 28.849533, y: 10}
+  - {x: 22.849533, y: 10}
+  - {x: -16.433025, y: 0.00000023841858}
+  - {x: -18.385586, y: 0.00000023841858}
+  - {x: -16.433025, y: 10}
+  - {x: -18.385586, y: 10}
+  - {x: 0.35469437, y: 0}
+  - {x: -3.3195858, y: 0}
+  - {x: 0.35469437, y: 10}
+  - {x: -3.3195858, y: 10}
+  - {x: -22.785301, y: 0}
+  - {x: -29.040298, y: 0}
+  - {x: -22.785301, y: 10}
+  - {x: -29.040298, y: 10}
+  - {x: -16.616875, y: 0}
+  - {x: -18.738197, y: 0}
+  - {x: -16.616875, y: 10}
+  - {x: -18.738197, y: 10}
+  - {x: 3.8497229, y: 0}
+  - {x: -2.1502762, y: 0}
+  - {x: 3.8497229, y: 10}
+  - {x: -2.1502762, y: 10}
+  - {x: 18.118605, y: 0}
+  - {x: 15.813718, y: 0}
+  - {x: 18.118605, y: 10}
+  - {x: 15.813718, y: 10}
+  - {x: 0.5, y: 0.5}
+  - {x: 1.5000019, y: 1.5}
+  - {x: 7.500002, y: 1.5}
+  - {x: 9, y: 0}
+  - {x: 9.25, y: -5.999999}
+  - {x: 7.500002, y: -7.5}
+  - {x: 1.7500019, y: -7.5}
+  - {x: 0.25, y: -5.999999}
+  - {x: -1.5, y: 1.5}
+  - {x: -7.5, y: 1.5}
+  - {x: -0.08807373, y: 0.5}
+  - {x: -9, y: 0}
+  - {x: -7.5, y: -7.5}
+  - {x: -1.5978241, y: -7.5}
+  - {x: -0.07993317, y: -5.999999}
+  - {x: -9.25, y: -5.999999}
+  - {x: -1.5000019, y: 0.00000047683716}
+  - {x: -7.500002, y: 0.00000047683716}
+  - {x: -1.5000019, y: 10}
+  - {x: -7.500002, y: 10}
+  - {x: -0.3608551, y: -0.008500576}
+  - {x: -2.0910425, y: -0.008500576}
+  - {x: -0.697011, y: 9.994333}
+  - {x: -2.0910425, y: 9.988667}
+  - {x: -4.2426376, y: 0.00000047683716}
+  - {x: -6.3639565, y: 0.00000047683716}
+  - {x: -4.2426376, y: 10}
+  - {x: -6.3639565, y: 10}
+  - {x: 7.500002, y: 0.00000047683716}
+  - {x: 1.597826, y: 0.00000047683716}
+  - {x: 7.500002, y: 10}
+  - {x: 1.7500019, y: 10}
+  - {x: 6.4082794, y: -0.045045853}
+  - {x: 4.274269, y: -0.045045853}
+  - {x: 6.5165176, y: 9.955526}
+  - {x: 4.395237, y: 9.95566}
+  - {x: 3.1183739, y: 0.00000047683716}
+  - {x: 0.813488, y: 0.00000047683716}
+  - {x: 3.1183739, y: 10}
+  - {x: 0.813488, y: 10}
+  - {x: -0.37467384, y: 0.00000047683716}
+  - {x: -6.379881, y: 0.00000047683716}
+  - {x: -0.37467384, y: 10}
+  - {x: -6.379881, y: 10}
+  - {x: 5.999893, y: 0.0014858246}
+  - {x: -0.5001106, y: 0.0014858246}
+  - {x: 5.9996796, y: 10.002934}
+  - {x: -0.5006275, y: 10.007047}
+  m_Textures2: []
+  m_Textures3: []
+  m_Tangents:
+  - {x: 1, y: 0.00000019577195, z: -1.5126363e-21, w: -1}
+  - {x: 1, y: 0.00000019354928, z: -4.4508493e-21, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0.00000007406462, z: -1.4929269e-21, w: -1}
+  - {x: 1, y: -0.00000015108587, z: -0.000000037771475, w: -1}
+  - {x: 1, y: -0.00000014437005, z: -0.000000036092512, w: -1}
+  - {x: 1, y: -0.00000018949939, z: -0.00000004737485, w: -1}
+  - {x: 1, y: -0.00000030552968, z: -0.00000007638241, w: -1}
+  - {x: 1, y: -0.0000001882153, z: -0.00000004705383, w: -1}
+  - {x: 1, y: -0.000000071978626, z: 1.1476603e-21, w: -1}
+  - {x: 1, y: -0.000000023879123, z: 0, w: -1}
+  - {x: 1, y: -0.00000016933618, z: 0, w: -1}
+  - {x: 1, y: -0.0000001105229, z: 1.9939744e-21, w: -1}
+  - {x: -1, y: 0.0000001510859, z: 5.1073225e-21, w: -1}
+  - {x: -1, y: 0.00000018949943, z: 8.911416e-21, w: -1}
+  - {x: -1, y: 0.00000014437003, z: 9.070359e-21, w: -1}
+  - {x: -1, y: 0.00000030552974, z: 0, w: -1}
+  - {x: -1, y: 0.00000018821532, z: 0, w: -1}
+  - {x: -1, y: 0.00000007197864, z: 1.1476604e-21, w: -1}
+  - {x: -1, y: -0.00000007406462, z: 0, w: -1}
+  - {x: -1, y: -0.00000019354928, z: 4.4508493e-21, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: -0.00000019577195, z: 1.5126364e-21, w: -1}
+  - {x: -1, y: 0.00000011052291, z: 9.969872e-22, w: -1}
+  - {x: -1, y: 0.0000001693362, z: 4.3038122e-21, w: -1}
+  - {x: -1, y: 0.000000023879128, z: 1.0816589e-21, w: -1}
+  - {x: -0.36786425, y: 1.9821575e-15, z: 0.92987955, w: -1}
+  - {x: -0.36786422, y: 0, z: 0.92987955, w: -1}
+  - {x: -0.36786422, y: 0, z: 0.92987955, w: -1}
+  - {x: -0.3678642, y: 0, z: 0.92987955, w: -1}
+  - {x: 0.97536063, y: 9.281716e-16, z: 0.22061652, w: -1}
+  - {x: 0.97536063, y: 9.281716e-16, z: 0.22061652, w: -1}
+  - {x: 0.97536063, y: 9.281716e-16, z: 0.22061652, w: -1}
+  - {x: 0.97536063, y: 9.281716e-16, z: 0.22061652, w: -1}
+  - {x: -0.93448776, y: 0, z: -0.3559954, w: -1}
+  - {x: -0.93448776, y: 0, z: -0.35599533, w: -1}
+  - {x: -0.93448776, y: 0, z: -0.35599533, w: -1}
+  - {x: -0.93448776, y: 0, z: -0.35599527, w: -1}
+  - {x: 0.3433642, y: 1.5140802e-15, z: -0.9392023, w: -1}
+  - {x: 0.34336424, y: 0, z: -0.9392023, w: -1}
+  - {x: 0.34336424, y: 0, z: -0.9392023, w: -1}
+  - {x: 0.34336424, y: 0, z: -0.9392023, w: -1}
+  - {x: 0.39054948, y: 0, z: -0.92058194, w: -1}
+  - {x: 0.39054948, y: 1.4073342e-15, z: -0.92058194, w: -1}
+  - {x: 0.39054948, y: 1.4073342e-15, z: -0.92058194, w: -1}
+  - {x: 0.39054948, y: 0, z: -0.92058194, w: -1}
+  - {x: -0.3713907, y: 0, z: 0.9284767, w: -1}
+  - {x: -0.3713907, y: 0, z: 0.9284767, w: -1}
+  - {x: -0.3713907, y: 0, z: 0.9284767, w: -1}
+  - {x: -0.3713907, y: 0, z: 0.9284767, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -0.7071067, y: 0, z: 0.7071068, w: -1}
+  - {x: -0.70710677, y: -2.9046726e-16, z: 0.7071068, w: -1}
+  - {x: -0.70710677, y: -2.9046726e-16, z: 0.7071068, w: -1}
+  - {x: -0.70710677, y: -3.2971957e-16, z: 0.7071068, w: -1}
+  - {x: -0.024228146, y: 1.2865703e-16, z: 0.9997065, w: -1}
+  - {x: -0.024228144, y: 1.2193546e-16, z: 0.9997065, w: -1}
+  - {x: -0.024228144, y: 1.2193546e-16, z: 0.9997065, w: -1}
+  - {x: -0.024228144, y: 1.1521387e-16, z: 0.9997065, w: -1}
+  - {x: 0.9998001, y: -3.4779696e-17, z: 0.019995982, w: -1}
+  - {x: 0.9998001, y: -1.7389848e-17, z: 0.019995982, w: -1}
+  - {x: 0.9998001, y: -1.7389848e-17, z: 0.019995982, w: -1}
+  - {x: 0.9998001, y: 0, z: 0.019995982, w: -1}
+  - {x: -0.70710707, y: 2.0097182e-15, z: -0.70710653, w: -1}
+  - {x: -0.70710707, y: 2.0097182e-15, z: -0.70710653, w: -1}
+  - {x: -0.70710707, y: 2.0097182e-15, z: -0.70710653, w: -1}
+  - {x: -0.70710707, y: 2.0097182e-15, z: -0.70710653, w: -1}
+  - {x: -0.999232, y: -1.7053854e-16, z: 0.039185435, w: -1}
+  - {x: -0.999232, y: -1.6879837e-16, z: 0.03918543, w: -1}
+  - {x: -0.999232, y: -1.6879837e-16, z: 0.03918543, w: -1}
+  - {x: -0.999232, y: 0, z: 0.03918543, w: -1}
+  - {x: -0.010203351, y: 0, z: -0.99994797, w: -1}
+  - {x: -0.010203351, y: 0, z: -0.99994797, w: -1}
+  - {x: -0.010203351, y: 0, z: -0.99994797, w: -1}
+  - {x: -0.010203351, y: 0, z: -0.99994797, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0.000000071346726, w: -1}
+  - {x: 1, y: 0, z: 0.00000046170385, w: -1}
+  - {x: 1, y: 0, z: 0.00000023252144, w: -1}
+  - {x: 1, y: 0, z: -0.000000013996662, w: -1}
+  - {x: 1, y: 0, z: -0.00000026918434, w: -1}
+  - {x: 1, y: 0, z: -0.0000000044726107, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0.000000038015205, w: -1}
+  - {x: 1, y: 0, z: 0.00000030666774, w: -1}
+  - {x: 1, y: 0, z: 0.00000006011751, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: -0.000000012818203, w: -1}
+  - {x: 1, y: 0, z: -0.0000000220659, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0.00000005246468, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: -0.000000071346726, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: -0.00000005246468, w: -1}
+  - {x: -1, y: 0, z: -0.00000046170385, w: -1}
+  - {x: -1, y: 0, z: -0.00000023252144, w: -1}
+  - {x: -1, y: 0, z: 0.0000000139966625, w: -1}
+  - {x: -1, y: 0, z: 0.00000026918434, w: -1}
+  - {x: -1, y: 0, z: 0.0000000044726107, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: -0.000000038015205, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: -0.00000030666774, w: -1}
+  - {x: -1, y: 0, z: -0.000000060117515, w: -1}
+  - {x: -1, y: 0, z: 0.000000012818203, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0.0000000220659, w: -1}
+  - {x: -0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: -0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: -0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: -0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -0.9863939, y: 0, z: -0.16439898, w: -1}
+  - {x: -0.9863939, y: 0, z: -0.16439898, w: -1}
+  - {x: -0.9863939, y: 0, z: -0.16439898, w: -1}
+  - {x: -0.9863939, y: 0, z: -0.16439898, w: -1}
+  - {x: -0.47345325, y: 0, z: 0.88081896, w: -1}
+  - {x: -0.47345325, y: 0, z: 0.88081896, w: -1}
+  - {x: -0.47345325, y: 0, z: 0.88081896, w: -1}
+  - {x: -0.47345325, y: 0, z: 0.88081896, w: -1}
+  - {x: 0.99589866, y: 0, z: 0.090475775, w: -1}
+  - {x: 0.99589866, y: 0, z: 0.090475775, w: -1}
+  - {x: 0.99589866, y: 0, z: 0.090475775, w: -1}
+  - {x: 0.99589866, y: 0, z: 0.090475775, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: 0.08985082, y: 0, z: 0.9959553, w: -1}
+  - {x: 0.08985082, y: 0, z: 0.9959553, w: -1}
+  - {x: 0.08985082, y: 0, z: 0.9959553, w: -1}
+  - {x: 0.08985082, y: 0, z: 0.9959553, w: -1}
+  - {x: -0.7682213, y: 0, z: -0.64018434, w: -1}
+  - {x: -0.7682213, y: 0, z: -0.64018434, w: -1}
+  - {x: -0.7682213, y: 0, z: -0.64018434, w: -1}
+  - {x: -0.7682213, y: 0, z: -0.64018434, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0.72413814, y: 0, z: 0.689655, w: -1}
+  - {x: 0.72413814, y: 0, z: 0.689655, w: -1}
+  - {x: 0.72413814, y: 0, z: 0.689655, w: -1}
+  - {x: 0.72413814, y: 0, z: 0.689655, w: -1}
+  - {x: 0.99993, y: 0, z: 0.011833461, w: -1}
+  - {x: 0.99993, y: 0, z: 0.011833461, w: -1}
+  - {x: 0.99993, y: 0, z: 0.011833461, w: -1}
+  - {x: 0.99993, y: 0, z: 0.011833461, w: -1}
+  - {x: 0.02082905, y: 0, z: -0.99978304, w: -1}
+  - {x: 0.02082905, y: 0, z: -0.99978304, w: -1}
+  - {x: 0.02082905, y: 0, z: -0.99978304, w: -1}
+  - {x: 0.02082905, y: 0, z: -0.99978304, w: -1}
+  - {x: 0.7249994, y: 0, z: -0.68874955, w: -1}
+  - {x: 0.7249994, y: 0, z: -0.68874955, w: -1}
+  - {x: 0.7249994, y: 0, z: -0.68874955, w: -1}
+  - {x: 0.7249994, y: 0, z: -0.68874955, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.9950372, y: 0, z: -0.09950372, w: -1}
+  - {x: -0.9950372, y: 0, z: -0.09950372, w: -1}
+  - {x: -0.9950372, y: 0, z: -0.09950372, w: -1}
+  - {x: -0.9950372, y: 0, z: -0.09950372, w: -1}
+  - {x: 0.999406, y: 0, z: 0.034462348, w: -1}
+  - {x: 0.999406, y: 0, z: 0.034462348, w: -1}
+  - {x: 0.999406, y: 0, z: 0.034462348, w: -1}
+  - {x: 0.999406, y: 0, z: 0.034462348, w: -1}
+  - {x: -0.8320503, y: 0, z: 0.5547002, w: -1}
+  - {x: -0.8320503, y: 0, z: 0.5547002, w: -1}
+  - {x: -0.8320503, y: 0, z: 0.5547002, w: -1}
+  - {x: -0.8320503, y: 0, z: 0.5547002, w: -1}
+  - {x: 0.91707045, y: 0, z: -0.39872524, w: -1}
+  - {x: 0.91707045, y: 0, z: -0.39872524, w: -1}
+  - {x: 0.91707045, y: 0, z: -0.39872524, w: -1}
+  - {x: 0.91707045, y: 0, z: -0.39872524, w: -1}
+  - {x: 0.999201, y: 0, z: 0.039967444, w: -1}
+  - {x: 0.999201, y: 0, z: 0.039967444, w: -1}
+  - {x: 0.999201, y: 0, z: 0.039967444, w: -1}
+  - {x: 0.999201, y: 0, z: 0.039967444, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -0.31622776, y: 0, z: -0.9486833, w: -1}
+  - {x: -0.31622776, y: 0, z: -0.9486833, w: -1}
+  - {x: -0.31622776, y: 0, z: -0.9486833, w: -1}
+  - {x: -0.31622776, y: 0, z: -0.9486833, w: -1}
+  - {x: 0.24253663, y: 0, z: 0.97014225, w: -1}
+  - {x: 0.24253663, y: 0, z: 0.97014225, w: -1}
+  - {x: 0.24253663, y: 0, z: 0.97014225, w: -1}
+  - {x: 0.24253663, y: 0, z: 0.97014225, w: -1}
+  - {x: 0.40613696, y: 0, z: 0.9138122, w: -1}
+  - {x: 0.40613696, y: 0, z: 0.9138122, w: -1}
+  - {x: 0.40613696, y: 0, z: 0.9138122, w: -1}
+  - {x: 0.40613696, y: 0, z: 0.9138122, w: -1}
+  - {x: 0.88701767, y: 0, z: -0.46173558, w: -1}
+  - {x: 0.88701767, y: 0, z: -0.46173558, w: -1}
+  - {x: 0.88701767, y: 0, z: -0.46173558, w: -1}
+  - {x: 0.88701767, y: 0, z: -0.46173558, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.89442724, y: 0, z: 0.44721362, w: -1}
+  - {x: -0.9486833, y: 0, z: -0.31622776, w: -1}
+  - {x: -0.9486833, y: 0, z: -0.31622776, w: -1}
+  - {x: -0.9486833, y: 0, z: -0.31622776, w: -1}
+  - {x: -0.9486833, y: 0, z: -0.31622776, w: -1}
+  - {x: 0.9977853, y: 0, z: -0.066517845, w: -1}
+  - {x: 0.9977853, y: 0, z: -0.066517845, w: -1}
+  - {x: 0.9977853, y: 0, z: -0.066517845, w: -1}
+  - {x: 0.9977853, y: 0, z: -0.066517845, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: 0, y: 0, z: 1, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: 0.6401844, y: 0, z: 0.7682213, w: -1}
+  - {x: 0.6401844, y: 0, z: 0.7682213, w: -1}
+  - {x: 0.6401844, y: 0, z: 0.7682213, w: -1}
+  - {x: 0.6401844, y: 0, z: 0.7682213, w: -1}
+  - {x: -0.01310696, y: 0, z: 0.9999141, w: -1}
+  - {x: -0.01310696, y: 0, z: 0.9999141, w: -1}
+  - {x: -0.01310696, y: 0, z: 0.9999141, w: -1}
+  - {x: -0.01310696, y: 0, z: 0.9999141, w: -1}
+  - {x: 0.99920094, y: 0, z: 0.03996804, w: -1}
+  - {x: 0.99920094, y: 0, z: 0.03996804, w: -1}
+  - {x: 0.99920094, y: 0, z: 0.03996804, w: -1}
+  - {x: 0.99920094, y: 0, z: 0.03996804, w: -1}
+  - {x: 0.7071068, y: 0, z: -0.7071068, w: -1}
+  - {x: 0.7071068, y: 0, z: -0.7071068, w: -1}
+  - {x: 0.7071068, y: 0, z: -0.7071068, w: -1}
+  - {x: 0.7071068, y: 0, z: -0.7071068, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: 0, y: 0, z: -1, w: -1}
+  - {x: -0.65079147, y: 0, z: -0.7592566, w: -1}
+  - {x: -0.65079147, y: 0, z: -0.7592566, w: -1}
+  - {x: -0.65079147, y: 0, z: -0.7592566, w: -1}
+  - {x: -0.65079147, y: 0, z: -0.7592566, w: -1}
+  - {x: 1, y: 0, z: -0.0000000028703513, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0.00000002441683, w: -1}
+  - {x: 1, y: 0, z: 0.00000013154128, w: -1}
+  - {x: 1, y: 0, z: 0.00000003542613, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: -0.000000011291315, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0.0000000027436788, w: -1}
+  - {x: -1, y: 0, z: -0.000000024650971, w: -1}
+  - {x: -1, y: 0, z: -0.000000035611635, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0.000000010979137, w: -1}
+  - {x: -1, y: 0, z: -0.00000013154128, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -1, y: 0, z: 0, w: -1}
+  - {x: -0.816056, y: -0.0000000014186783, z: -0.5779728, w: -1}
+  - {x: -0.7643201, y: -0.0020182773, z: -0.6448339, w: -1}
+  - {x: -0.7643201, y: -0.0020182773, z: -0.6448339, w: -1}
+  - {x: -0.70710176, y: -0.0040080845, z: -0.70710045, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: -0.7071068, y: 0, z: 0.7071068, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 1, y: 0, z: 0, w: -1}
+  - {x: 0.7112867, y: -6.3752315e-10, z: -0.702902, w: -1}
+  - {x: 0.7092003, y: 0.000031692565, z: -0.705007, w: -1}
+  - {x: 0.7092003, y: 0.000031692565, z: -0.705007, w: -1}
+  - {x: 0.7071078, y: 0.00006338394, z: -0.7071058, w: -1}
+  - {x: 0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: 0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: 0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: 0.7592566, y: 0, z: 0.6507914, w: -1}
+  - {x: -0.04163055, y: 0, z: 0.99913305, w: -1}
+  - {x: -0.04163055, y: 0, z: 0.99913305, w: -1}
+  - {x: -0.04163055, y: 0, z: 0.99913305, w: -1}
+  - {x: -0.04163055, y: 0, z: 0.99913305, w: -1}
+  - {x: -0.0012523937, y: 0, z: -0.9999992, w: -1}
+  - {x: -0.019830478, y: 0.00031596236, z: -0.9998033, w: -1}
+  - {x: -0.019830478, y: 0.00031596236, z: -0.9998033, w: -1}
+  - {x: -0.038407117, y: 0.0006321278, z: -0.999262, w: -1}
+  m_Colors: []
+  m_UnwrapParameters:
+    m_HardAngle: 88
+    m_PackMargin: 20
+    m_AngleError: 8
+    m_AreaError: 15
+  m_PreserveMeshAssetOnDestroy: 0
+  assetGuid: 
+  m_Mesh: {fileID: 570173377}
+  m_VersionIndex: 30
+  m_IsSelectable: 1
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
+--- !u!4 &1876845935
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876845929}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -9.933611, y: -1.78, z: 2.0106404}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1881817049
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -80283,12 +89296,12 @@ PrefabInstance:
     - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -36.4
+      value: -36.23
       objectReference: {fileID: 0}
     - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.9
+      value: 1.74
       objectReference: {fileID: 0}
     - target: {fileID: 3875646670198489922, guid: 9e25d2db60cabff4bac177ff0757bf31,
         type: 3}
@@ -80584,6 +89597,86 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1001 &1885996505
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.169999
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (67)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1885996506 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1885996505}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1885996507 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1885996505}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1890562896 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4014943590051314144, guid: 3d56d25e45bd22d479558b321ce093fb,
@@ -80708,6 +89801,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &1894405509
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.4700003
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (26)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1894405510 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1894405509}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1894405511 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1894405509}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1895139376
 GameObject:
   m_ObjectHideFlags: 0
@@ -81238,6 +90411,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 216516126955895849, guid: 275d6fdecfed5954895fed50f3a87440,
     type: 3}
   m_PrefabInstance: {fileID: 300395762}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1920741394
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (11)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1920741395 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1920741394}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1920741396 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1920741394}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1927236630 stripped
 Transform:
@@ -81916,110 +91169,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10eae269a1bbe614882ffda5fc877d60, type: 3}
---- !u!1001 &1947654258
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1394060812}
-    m_Modifications:
-    - target: {fileID: 66097493073879181, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_Name
-      value: Melee AI (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3854924872114529646, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: maxDetectionRange
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034315216963791772, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -33
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 16.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9166431296155532778, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00da7ea1c10f6aa4faa8fb578857dcf5, type: 3}
---- !u!4 &1947654259 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8983775168675799407, guid: 00da7ea1c10f6aa4faa8fb578857dcf5,
-    type: 3}
-  m_PrefabInstance: {fileID: 1947654258}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1949479624 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
@@ -82693,6 +91842,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10eae269a1bbe614882ffda5fc877d60, type: 3}
+--- !u!1001 &1987588752
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.970001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (9)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &1987588753 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1987588752}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1987588754 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 1987588752}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1993517592
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -82942,6 +92171,86 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63a2800cc380c0f448ca9f2c58c53a04, type: 3}
+--- !u!1001 &2003347513
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.009998
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.100002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (70)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &2003347514 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2003347513}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2003347515 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2003347513}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2005572983
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -83015,6 +92324,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6034063488059620566, guid: 10eae269a1bbe614882ffda5fc877d60,
     type: 3}
   m_PrefabInstance: {fileID: 669284001}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2008569555
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.060005
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (58)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &2008569556 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2008569555}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2008569557 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2008569555}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &2010403607 stripped
 Transform:
@@ -83622,6 +93011,86 @@ LightProbeGroup:
   - {x: -1, y: -1, z: 1}
   - {x: -1, y: -1, z: -1}
   m_Dering: 1
+--- !u!1001 &2039821271
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.9900017
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 33.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (85)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &2039821272 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2039821271}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2039821273 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2039821271}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2043251261 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8113442389928652711, guid: 63a2800cc380c0f448ca9f2c58c53a04,
@@ -84245,6 +93714,166 @@ Transform:
   - {fileID: 1156837289}
   m_Father: {fileID: 1995281437}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2065490775
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.1899996
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (16)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &2065490776 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2065490775}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2065490777 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2065490775}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2065890836
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &2065890837 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2065890836}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2065890838 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2065890836}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2067901135
 GameObject:
   m_ObjectHideFlags: 0
@@ -84466,6 +94095,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 722473921180735867, guid: c4afcfa87699ef64bbfbf611d84cc05e,
     type: 3}
   m_PrefabInstance: {fileID: 1232357078}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2082724073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.970001
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.060005
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (59)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &2082724074 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2082724073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2082724075 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2082724073}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2083911485
 PrefabInstance:
@@ -86312,6 +96021,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 948018948}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2122197981
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 484792077}
+    m_Modifications:
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.350002
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.1899996
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+        type: 3}
+      propertyPath: m_Name
+      value: AI Spawnpoint (12)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df3c356cf6668cc41b48319dba8bb350, type: 3}
+--- !u!4 &2122197982 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 858719323519997246, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2122197981}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2122197983 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3067870244429275663, guid: df3c356cf6668cc41b48319dba8bb350,
+    type: 3}
+  m_PrefabInstance: {fileID: 2122197981}
+  m_PrefabAsset: {fileID: 0}
 --- !u!43 &2122433442
 Mesh:
   m_ObjectHideFlags: 0
@@ -86825,3 +96614,4 @@ SceneRoots:
   - {fileID: 721572250}
   - {fileID: 1873533147}
   - {fileID: 886490705}
+  - {fileID: 1876845935}


### PR DESCRIPTION
reworked 1Bs combat to be more horde focused, and made the boss minions stop spawning on the bosses death also added a temporary fix to the fountain colliders to prevent sequence breaks