### PR TITLE
fixed some lvl2 dialogue errors and modified ending slightly

### DIFF
--- a/Assets/Design/narrative animations/Van.controller
+++ b/Assets/Design/narrative animations/Van.controller
@@ -104,7 +104,7 @@ AnimatorController:
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
-    m_DefaultBool: 1
+    m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
   - m_Name: drive
     m_Type: 4

--- a/Assets/Programming/Ending/EndingAudio.cs
+++ b/Assets/Programming/Ending/EndingAudio.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class EndingAudio : MonoBehaviour
 {
+    [SerializeField] private Animator animator;
+
     [SerializeField] private AudioClip startEngineClip;
     [SerializeField] private AudioClip runningEngineClip;
 
@@ -11,20 +13,27 @@ public class EndingAudio : MonoBehaviour
 
     private void Awake()
     {
+        animator = GetComponent<Animator>();
+        animator.SetBool("road?", false);
+
         audioSource = GetComponent<AudioSource>();
-        audioSource.clip = startEngineClip;
         audioSource.loop = false;
-        audioSource.Play();
+        
+        StartCoroutine("PlayEndingAudio");
     }
 
-    private void Update()
+    private IEnumerator PlayEndingAudio()
     {
-        //once stopped playing is detected we can play running engine clip looping
-        if (!audioSource.isPlaying)
-        {
-            audioSource.clip = runningEngineClip;
-            audioSource.loop = true;
-            audioSource.Play();
-        }
+        yield return new WaitForSeconds(2f);
+
+        animator.SetBool("road?", true);
+
+        audioSource.clip = startEngineClip;
+        audioSource.Play();
+
+        yield return new WaitForSeconds(startEngineClip.length);
+
+        audioSource.clip = runningEngineClip;
+        audioSource.Play();
     }
 }

--- a/Assets/Scenes/Levels/Level 2/Level_2A.unity
+++ b/Assets/Scenes/Levels/Level 2/Level_2A.unity
@@ -51312,7 +51312,7 @@ PrefabInstance:
     - target: {fileID: 6854391596929836033, guid: 241e51dc5a7fac6479e5c6ac305908b2,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7316108949022290800, guid: 241e51dc5a7fac6479e5c6ac305908b2,
         type: 3}
@@ -51962,7 +51962,7 @@ GameObject:
   m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1431129691
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/level 3 ending/Level_3_Ending.unity
+++ b/Assets/Scenes/Levels/level 3 ending/Level_3_Ending.unity
@@ -5155,7 +5155,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 4616847991055122877, guid: 89ebef302e5dc5b44b9de23ccf24f487,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1618348749}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 781429325500691246, guid: 89ebef302e5dc5b44b9de23ccf24f487,
         type: 3}
@@ -5311,6 +5315,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 295d91b8c853f804d9300f300196d4b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  animator: {fileID: 449867381}
   startEngineClip: {fileID: 8300000, guid: fe0407aa0096cb34ca0954941f60dbf7, type: 3}
   runningEngineClip: {fileID: 8300000, guid: ca5c9d8e5e2f2404a85e2ac03e0e6dd4, type: 3}
 --- !u!1001 &452941118
@@ -18940,11 +18945,11 @@ Transform:
   m_GameObject: {fileID: 1618348748}
   serializedVersion: 2
   m_LocalRotation: {x: -0.0109616015, y: -0, z: -0, w: 0.9999399}
-  m_LocalPosition: {x: -4.929, y: 1.77, z: -38.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0.08160931, y: 1.6471266, z: 2.4666665}
+  m_LocalScale: {x: 1.1494253, y: 1.1494253, z: 1.1494253}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1973903568}
+  m_Father: {fileID: 449867378}
   m_LocalEulerAnglesHint: {x: -1.256, y: 0, z: 0}
 --- !u!114 &1618348750
 MonoBehaviour:
@@ -19020,7 +19025,7 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_RenderingLayerMask: 1
-  m_Lightmapping: 2
+  m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
@@ -23122,7 +23127,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1618348749}
   - {fileID: 1691053853}
   - {fileID: 112875824}
   - {fileID: 529615552}


### PR DESCRIPTION
CHANGELOG:
Level 2A
- Enabled dialogue canvas in 2A
- Disabled Dialogue trigger area for act 2.8 since it automatically plays on priest death (it was playing twice)

Level 3
- Modified ending audio script to have a 2 second delay before playing ending cutscene
- Attached van light to van